### PR TITLE
chore: add .gitignore to exclude .strawpot directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.strawpot/


### PR DESCRIPTION
## Summary
- Adds a `.gitignore` file to the project root with a single entry: `.strawpot/`
- Prevents the `.strawpot` local configuration directory from being tracked by git

## Test plan
- [x] Verified `.gitignore` did not exist on `main` before this change
- [ ] Confirm `.strawpot/` directory is excluded from `git status` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)