### PR TITLE
docs: REST-first architecture, scoping, sync, and change detection

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -924,11 +924,35 @@ bin/
 
 2. **Install record filtering** — Relava tracks which files it installed in `installations.installed_files_json`. On sync/publish, it can automatically exclude files it knows it placed (binaries, generated artifacts) unless the user explicitly modified them.
 
+### Change Detection
+
+Before publishing, Relava compares the local resource directory against the version currently in the registry. If nothing has changed, it skips the publish and reports "no changes detected."
+
+```bash
+$ relava publish skill denden
+Comparing skill denden against registry version 1.2.0...
+No changes detected. Nothing to publish.
+
+$ relava publish skill denden
+Comparing skill denden against registry version 1.2.0...
+  [modified] SKILL.md
+  [added]    templates/review-checklist.md
+Publish as 1.3.0? [Y/n] y
+Published skill denden@1.3.0
+```
+
+Change detection works by comparing SHA-256 checksums of each file (after applying `.relavaignore` filters) against the checksums stored in the registry for the latest version. This is a content-level comparison — timestamps are ignored.
+
+### Publish Flow
+
 On `relava publish`, the CLI:
 1. Reads `.relavaignore` if present
 2. Collects all files in the resource directory, excluding ignored patterns
-3. Validates file limits (100 files, 10 MB each, 50 MB total)
-4. Uploads via multipart HTTP POST as a new version
+3. Computes SHA-256 per file and compares against the latest published version in the registry
+4. If no files changed: print "no changes detected" and exit
+5. If changes exist: show a diff summary (added/modified/removed files) and prompt for confirmation
+6. Validates file limits (100 files, 10 MB each, 50 MB total)
+7. Uploads via multipart HTTP POST as a new version
 
 ### Name Conflicts on Publish
 


### PR DESCRIPTION
## Summary

Design decisions from architecture discussion:

- **REST-first**: Remove direct mode fallback. CLI always requires the server — enables enterprise deployment where the same CLI points at `localhost:7420` or `registry.company.com`
- **Scoping**: Add nullable `scope` column to DB schema for future `@org/name` support. No CLI/API changes yet
- **Sync**: Add `.relavaignore` + install record filtering to exclude binaries when publishing local changes back to registry
- **Change detection**: Compare SHA-256 checksums before publish — skip if no changes, show diff summary and prompt when changes exist
- **Name conflicts**: Same resource requires version bump, different owner gets rejection with rename suggestion
- Remove direct mode fallback from implementation checklist
- Renumber sections 9-13

## Test plan

- [ ] Verify DESIGN.md section numbering is consistent
- [ ] Verify DB schema includes nullable `scope` column
- [ ] Verify sync section describes `.relavaignore` and change detection flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)