### PR TITLE
docs: enterprise scoping and permissions model

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -307,10 +307,21 @@ Not implemented in MVP, but the schema and API are designed to accommodate:
 -- CREATE TABLE resource_permissions (resource_id, scope_type, scope_id, permission);  -- permission: 'read' | 'write'
 ```
 
+**Visibility & sharing permissions (per scope):**
+- **Global** — default visibility is `public` (all users can read). Write requires `publish` permission (configurable: open to all, or restricted to admins).
+- **Team** — default visibility is team members only. Admins can grant `read` to other teams or individual users for cross-team sharing. Write requires `member` or `admin` role.
+- **Personal** — default visibility is owner only. Owner can explicitly share `read` or `read+write` with specific users or teams.
+
+**Sharing model:**
+- Permissions are additive — a user's effective access is the union of their personal, team, and global permissions
+- Sharing is done via `resource_permissions` entries that grant `read` or `write` to a user or team on a specific resource
+- A team admin can make a team resource "public to org" (readable by all authenticated users) without moving it to global scope
+
 **Design constraints for MVP code:**
 - The `scope` column on `resources` is nullable — `NULL` means global (current behavior)
 - API paths should accept an optional scope prefix: `/resources/:type/:name` (global) and `/resources/:type/@:scope/:name` (scoped) — only the global form is implemented now
 - Resource slugs remain flat within a scope — `@team/foo` and `@user/foo` can coexist
+- No permission checks in MVP — all resources are globally readable and writable
 
 ### REST API
 


### PR DESCRIPTION
## Summary

Document future enterprise extension model (not implemented in MVP):

- **Scope types**: personal (`@user/name`), team (`@team/name`), global (no scope)
- **Users, teams, permissions**: reserved DB tables (commented out in schema)
- **Visibility per scope**:
  - Global: public read, configurable write
  - Team: members-only default, admins can share cross-team
  - Personal: owner-only, explicit sharing to users/teams
- **Additive permission model**: effective access = union of all grants
- **API path design**: optional `@scope` prefix for future use
- **MVP**: no permission checks, all resources globally readable/writable

## Test plan

- [ ] Verify future tables are commented out, not created
- [ ] Verify MVP constraint "no permission checks" is documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)