### PR TITLE
docs: mark item 3 as complete

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1007,7 +1007,7 @@ Trackable checklist of every deliverable from the Implementation Plan (Section 8
 
 - ✅ 1. Project scaffolding — Rust workspace, Cargo.toml, clap CLI skeleton with global options (`--server`, `--project`, `--verbose`, `--json`)
 - ✅ 2. Frontmatter parser — parse `metadata.relava` block from `.md` files to extract skill/agent dependency declarations
-- ⬜ 3. `relava.toml` parser — project manifest format (skills, agents, commands, rules sections with name=version constraint entries: `"X.Y.Z"` or `"*"`)
+- ✅ 3. `relava.toml` parser — project manifest format (skills, agents, commands, rules sections with name=version constraint entries: `"X.Y.Z"` or `"*"`)
 - ✅ 3a. Version constraint resolver — parse and resolve `"*"` to latest, `"X.Y.Z"` to exact version from local store
 - ✅ 4. Resource validation — validate directory structure per resource type (skill needs `SKILL.md`, agent needs `<name>.md`, etc.)
 - ✅ 4a. Slug validation — enforce slug format (1-64 chars, lowercase alphanumeric + hyphens, starts/ends with alphanumeric, no consecutive hyphens) on all resource names


### PR DESCRIPTION
## Summary

Mark item 3 (project manifest parser) as ✅ in DESIGN.md checklist. Already implemented as `ProjectManifest` in `src/manifest.rs` (PR #10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)