### PR TITLE
feat: skill post-install — tool checking and env var validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "tempfile",
  "toml",
 ]
 

--- a/crates/relava-cli/src/cli.rs
+++ b/crates/relava-cli/src/cli.rs
@@ -50,6 +50,10 @@ pub enum Command {
         /// Install globally to ~/.claude/
         #[arg(long)]
         global: bool,
+
+        /// Auto-accept tool install prompts
+        #[arg(long, short = 'y')]
+        yes: bool,
     },
 
     /// Remove a resource from the current project

--- a/crates/relava-cli/src/install.rs
+++ b/crates/relava-cli/src/install.rs
@@ -1,8 +1,11 @@
 use std::path::{Path, PathBuf};
 
 use relava_core::cache::DownloadCache;
+use relava_core::env_check::{self, EnvResult, EnvStatus};
+use relava_core::manifest::ResourceMeta;
 use relava_core::registry::RegistryClient;
 use relava_core::store::RelavaDir;
+use relava_core::tools::{self, ToolResult, ToolStatus};
 use relava_core::validate::{self, AgentType, ResourceType};
 use relava_core::version::Version;
 
@@ -16,6 +19,7 @@ pub struct InstallOpts<'a> {
     pub global: bool,
     pub json: bool,
     pub verbose: bool,
+    pub yes: bool,
 }
 
 /// Result of a successful install, used for JSON output.
@@ -26,6 +30,10 @@ pub struct InstallResult {
     pub version: String,
     pub files: Vec<String>,
     pub install_dir: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ToolResult>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<EnvResult>,
 }
 
 /// Run `relava install <type> <name>`.
@@ -108,6 +116,16 @@ pub fn run(opts: &InstallOpts) -> Result<InstallResult, String> {
             )
         };
         println!("  {type_tag:<10}{file_summary}");
+    }
+
+    // Post-install: tool checking and env var validation (skills only)
+    let (tool_results, env_results) = if opts.resource_type == ResourceType::Skill {
+        run_skill_post_install(opts, &install_dir)?
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
+    if !opts.json {
         println!("Installed {} {}@{}", opts.resource_type, opts.name, version);
     }
 
@@ -117,7 +135,108 @@ pub fn run(opts: &InstallOpts) -> Result<InstallResult, String> {
         version: version.to_string(),
         files: file_paths,
         install_dir: install_dir_display,
+        tools: tool_results,
+        env: env_results,
     })
+}
+
+/// Run skill-specific post-install steps: tool checking and env var validation.
+///
+/// Reads the installed SKILL.md frontmatter, checks tools, checks env vars.
+/// Tool/env failures are non-fatal — warnings only.
+fn run_skill_post_install(
+    opts: &InstallOpts,
+    install_dir: &Path,
+) -> Result<(Vec<ToolResult>, Vec<EnvResult>), String> {
+    if opts.resource_type != ResourceType::Skill {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let skill_md = install_dir.join("SKILL.md");
+    if !skill_md.exists() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let meta = match ResourceMeta::from_file(&skill_md) {
+        Ok(m) => m,
+        Err(e) => {
+            if !opts.json {
+                eprintln!("  [warn]    Could not parse skill metadata: {e}");
+            }
+            return Ok((Vec::new(), Vec::new()));
+        }
+    };
+
+    // Check and install tools
+    let prompt_fn: tools::PromptFn = Box::new(|msg| {
+        eprint!("            {msg} ");
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .map(|_| {
+                let trimmed = input.trim().to_lowercase();
+                trimmed.is_empty() || trimmed == "y" || trimmed == "yes"
+            })
+            .unwrap_or(false)
+    });
+    let tool_results = tools::check_and_install_tools(&meta.tools, opts.yes, Some(&prompt_fn));
+
+    // Check env vars
+    let project_root = if opts.global {
+        dirs::home_dir()
+            .ok_or_else(|| "cannot determine home directory for env check".to_string())?
+    } else {
+        opts.project_dir.to_path_buf()
+    };
+    let env_results = env_check::check_env_vars(&meta.env, &project_root);
+
+    if !opts.json {
+        for result in &tool_results {
+            print_tool_result(result);
+        }
+        for result in &env_results {
+            print_env_result(result);
+        }
+    }
+
+    Ok((tool_results, env_results))
+}
+
+/// Print a tool check result to stdout.
+fn print_tool_result(result: &ToolResult) {
+    let suffix = match &result.status {
+        ToolStatus::Found => "found on PATH".to_string(),
+        ToolStatus::Installed => "installed".to_string(),
+        ToolStatus::Declined => "declined".to_string(),
+        ToolStatus::Failed(err) => format!("install failed: {err}"),
+        ToolStatus::NoCommand => "not found, no install command for this OS".to_string(),
+        ToolStatus::Skipped => "not found on PATH (skipped)".to_string(),
+    };
+    println!("  [tool]    {} — {suffix}", result.name);
+}
+
+/// Print an env var check result to stdout.
+fn print_env_result(result: &EnvResult) {
+    match result.status {
+        EnvStatus::FoundInEnv | EnvStatus::FoundInSettings => {
+            // Don't print anything for found vars (clean output)
+        }
+        EnvStatus::MissingRequired => {
+            println!("  [warn]    Missing required env: {}", result.name);
+            if !result.description.is_empty() {
+                println!("            {}", result.description);
+            }
+            println!("            Set in .claude/settings.json under env");
+        }
+        EnvStatus::MissingOptional => {
+            if !result.description.is_empty() {
+                println!(
+                    "  [warn]    Missing optional env: {} — {}",
+                    result.name, result.description
+                );
+            }
+        }
+    }
 }
 
 /// The primary file name for display purposes.
@@ -296,6 +415,74 @@ mod tests {
         cache
     }
 
+    /// Set up a cached skill with tools and env metadata in its SKILL.md frontmatter.
+    fn setup_cache_with_skill_metadata(cache_dir: &Path) -> DownloadCache {
+        let cache = DownloadCache::new(cache_dir.to_path_buf());
+        let v = Version::parse("1.0.0").unwrap();
+        let skill_md = r#"---
+name: code-review
+description: Code review with security checks
+metadata:
+  relava:
+    tools:
+      sh:
+        description: Bourne shell
+        install:
+          macos: echo already-installed
+          linux: echo already-installed
+          windows: echo already-installed
+      fake-tool-xyz-never-exists:
+        description: A tool that never exists
+        install:
+          nonexistent-os: echo nope
+    env:
+      PATH:
+        required: true
+        description: System PATH (always set)
+      RELAVA_TEST_MISSING_REQ_VAR_12345:
+        required: true
+        description: A missing required var
+      RELAVA_TEST_MISSING_OPT_VAR_12345:
+        required: false
+        description: A missing optional var
+---
+# Code Review Skill
+Review code for security issues.
+"#;
+        let response = DownloadResponse {
+            resource_type: "skill".to_string(),
+            name: "code-review".to_string(),
+            version: "1.0.0".to_string(),
+            files: vec![DownloadFile {
+                path: "SKILL.md".to_string(),
+                content: encode_base64(skill_md.as_bytes()),
+            }],
+        };
+        cache
+            .store(ResourceType::Skill, "code-review", &v, &response)
+            .unwrap();
+        cache
+    }
+
+    /// Set up a cached skill with no frontmatter metadata.
+    fn setup_cache_with_plain_skill(cache_dir: &Path) -> DownloadCache {
+        let cache = DownloadCache::new(cache_dir.to_path_buf());
+        let v = Version::parse("1.0.0").unwrap();
+        let response = DownloadResponse {
+            resource_type: "skill".to_string(),
+            name: "plain-skill".to_string(),
+            version: "1.0.0".to_string(),
+            files: vec![DownloadFile {
+                path: "SKILL.md".to_string(),
+                content: encode_base64(b"# Plain Skill\nNo metadata."),
+            }],
+        };
+        cache
+            .store(ResourceType::Skill, "plain-skill", &v, &response)
+            .unwrap();
+        cache
+    }
+
     #[test]
     fn write_skill_to_project() {
         let project = temp_dir();
@@ -412,6 +599,7 @@ mod tests {
             global: false,
             json: false,
             verbose: false,
+            yes: false,
         };
         let result = run(&opts);
         assert!(result.is_err());
@@ -450,6 +638,7 @@ mod tests {
             global: false,
             json: false,
             verbose: false,
+            yes: false,
         };
         let result = run(&opts);
         assert!(result.is_err());
@@ -459,5 +648,338 @@ mod tests {
             err.contains("not reachable") || err.contains("error") || err.contains("HTTP"),
             "Error message should indicate server issue: {err}"
         );
+    }
+
+    // -- Post-install tests --
+
+    /// Install the "code-review" skill with metadata and return post-install results.
+    /// Shared setup for most post-install tests.
+    fn run_post_install_with_metadata(
+        project: &Path,
+    ) -> (PathBuf, Vec<ToolResult>, Vec<EnvResult>) {
+        let cache_dir = temp_dir();
+        let cache = setup_cache_with_skill_metadata(cache_dir.path());
+        let v = Version::parse("1.0.0").unwrap();
+        let install_dir =
+            write_to_project(project, ResourceType::Skill, "code-review", &v, &cache).unwrap();
+
+        let opts = InstallOpts {
+            server_url: "http://localhost:7420",
+            resource_type: ResourceType::Skill,
+            name: "code-review",
+            version_pin: None,
+            project_dir: project,
+            global: false,
+            json: true,
+            verbose: false,
+            yes: false,
+        };
+
+        let (tools, env) = run_skill_post_install(&opts, &install_dir).unwrap();
+        (install_dir, tools, env)
+    }
+
+    #[test]
+    fn post_install_parses_tool_metadata() {
+        let project = temp_dir();
+        let (install_dir, _, _) = run_post_install_with_metadata(project.path());
+
+        let meta = ResourceMeta::from_file(&install_dir.join("SKILL.md")).unwrap();
+        assert_eq!(meta.tools.len(), 2);
+        assert!(meta.tools.contains_key("sh"));
+        assert!(meta.tools.contains_key("fake-tool-xyz-never-exists"));
+    }
+
+    #[test]
+    fn post_install_parses_env_metadata() {
+        let project = temp_dir();
+        let (install_dir, _, _) = run_post_install_with_metadata(project.path());
+
+        let meta = ResourceMeta::from_file(&install_dir.join("SKILL.md")).unwrap();
+        assert_eq!(meta.env.len(), 3);
+        assert!(meta.env["PATH"].required);
+        assert!(meta.env["RELAVA_TEST_MISSING_REQ_VAR_12345"].required);
+        assert!(!meta.env["RELAVA_TEST_MISSING_OPT_VAR_12345"].required);
+    }
+
+    #[test]
+    fn post_install_tool_found_on_path() {
+        let project = temp_dir();
+        let (_, tool_results, _) = run_post_install_with_metadata(project.path());
+
+        let sh_result = tool_results.iter().find(|r| r.name == "sh").unwrap();
+        assert_eq!(sh_result.status, ToolStatus::Found);
+    }
+
+    #[test]
+    fn post_install_tool_no_command_for_os() {
+        let project = temp_dir();
+        let (_, tool_results, _) = run_post_install_with_metadata(project.path());
+
+        let missing = tool_results
+            .iter()
+            .find(|r| r.name == "fake-tool-xyz-never-exists")
+            .unwrap();
+        assert_eq!(missing.status, ToolStatus::NoCommand);
+    }
+
+    #[test]
+    fn post_install_env_found_in_process() {
+        let project = temp_dir();
+        let (_, _, env_results) = run_post_install_with_metadata(project.path());
+
+        let path_result = env_results.iter().find(|r| r.name == "PATH").unwrap();
+        assert_eq!(path_result.status, EnvStatus::FoundInEnv);
+    }
+
+    #[test]
+    fn post_install_env_missing_required() {
+        let project = temp_dir();
+        let (_, _, env_results) = run_post_install_with_metadata(project.path());
+
+        let missing = env_results
+            .iter()
+            .find(|r| r.name == "RELAVA_TEST_MISSING_REQ_VAR_12345")
+            .unwrap();
+        assert_eq!(missing.status, EnvStatus::MissingRequired);
+        assert!(missing.required);
+    }
+
+    #[test]
+    fn post_install_env_missing_optional() {
+        let project = temp_dir();
+        let (_, _, env_results) = run_post_install_with_metadata(project.path());
+
+        let optional = env_results
+            .iter()
+            .find(|r| r.name == "RELAVA_TEST_MISSING_OPT_VAR_12345")
+            .unwrap();
+        assert_eq!(optional.status, EnvStatus::MissingOptional);
+        assert!(!optional.required);
+    }
+
+    #[test]
+    fn post_install_env_in_settings_json() {
+        let project = temp_dir();
+        let cache_dir = temp_dir();
+        let cache = setup_cache_with_skill_metadata(cache_dir.path());
+        let v = Version::parse("1.0.0").unwrap();
+        let install_dir = write_to_project(
+            project.path(),
+            ResourceType::Skill,
+            "code-review",
+            &v,
+            &cache,
+        )
+        .unwrap();
+
+        // Write a settings.json with the missing required env var
+        let claude_dir = project.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(
+            claude_dir.join("settings.json"),
+            r#"{"env": {"RELAVA_TEST_MISSING_REQ_VAR_12345": "some-token"}}"#,
+        )
+        .unwrap();
+
+        let opts = InstallOpts {
+            server_url: "http://localhost:7420",
+            resource_type: ResourceType::Skill,
+            name: "code-review",
+            version_pin: None,
+            project_dir: project.path(),
+            global: false,
+            json: true,
+            verbose: false,
+            yes: false,
+        };
+
+        let (_, env_results) = run_skill_post_install(&opts, &install_dir).unwrap();
+
+        let req = env_results
+            .iter()
+            .find(|r| r.name == "RELAVA_TEST_MISSING_REQ_VAR_12345")
+            .unwrap();
+        assert_eq!(req.status, EnvStatus::FoundInSettings);
+    }
+
+    #[test]
+    fn post_install_skipped_for_non_skills() {
+        let project = temp_dir();
+        let install_dir = project.path().join(".claude/agents");
+        fs::create_dir_all(&install_dir).unwrap();
+
+        let opts = InstallOpts {
+            server_url: "http://localhost:7420",
+            resource_type: ResourceType::Agent,
+            name: "debugger",
+            version_pin: None,
+            project_dir: project.path(),
+            global: false,
+            json: true,
+            verbose: false,
+            yes: false,
+        };
+
+        let (tools, env) = run_skill_post_install(&opts, &install_dir).unwrap();
+        assert!(tools.is_empty());
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn post_install_no_metadata_in_skill() {
+        let project = temp_dir();
+        let cache_dir = temp_dir();
+        let cache = setup_cache_with_plain_skill(cache_dir.path());
+        let v = Version::parse("1.0.0").unwrap();
+        let install_dir = write_to_project(
+            project.path(),
+            ResourceType::Skill,
+            "plain-skill",
+            &v,
+            &cache,
+        )
+        .unwrap();
+
+        let opts = InstallOpts {
+            server_url: "http://localhost:7420",
+            resource_type: ResourceType::Skill,
+            name: "plain-skill",
+            version_pin: None,
+            project_dir: project.path(),
+            global: false,
+            json: true,
+            verbose: false,
+            yes: false,
+        };
+
+        let (tools, env) = run_skill_post_install(&opts, &install_dir).unwrap();
+        assert!(tools.is_empty());
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn post_install_malformed_frontmatter_warns_not_errors() {
+        let project = temp_dir();
+        let cache_dir = temp_dir();
+        let cache = DownloadCache::new(cache_dir.path().to_path_buf());
+        let v = Version::parse("1.0.0").unwrap();
+        // Malformed YAML frontmatter
+        let skill_md = "---\nmetadata:\n  relava:\n    tools: [invalid\n---\n# Bad Skill\n";
+        let response = DownloadResponse {
+            resource_type: "skill".to_string(),
+            name: "bad-meta".to_string(),
+            version: "1.0.0".to_string(),
+            files: vec![DownloadFile {
+                path: "SKILL.md".to_string(),
+                content: encode_base64(skill_md.as_bytes()),
+            }],
+        };
+        cache
+            .store(ResourceType::Skill, "bad-meta", &v, &response)
+            .unwrap();
+
+        let install_dir =
+            write_to_project(project.path(), ResourceType::Skill, "bad-meta", &v, &cache).unwrap();
+
+        let opts = InstallOpts {
+            server_url: "http://localhost:7420",
+            resource_type: ResourceType::Skill,
+            name: "bad-meta",
+            version_pin: None,
+            project_dir: project.path(),
+            global: false,
+            json: true,
+            verbose: false,
+            yes: false,
+        };
+
+        // Should return Ok with empty results, not Err
+        let (tools, env) = run_skill_post_install(&opts, &install_dir).unwrap();
+        assert!(tools.is_empty());
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn install_result_serializes_with_tools_and_env() {
+        let result = InstallResult {
+            resource_type: "skill".to_string(),
+            name: "code-review".to_string(),
+            version: "1.0.0".to_string(),
+            files: vec!["SKILL.md".to_string()],
+            install_dir: ".claude/skills/code-review".to_string(),
+            tools: vec![ToolResult {
+                name: "gh".to_string(),
+                description: "GitHub CLI".to_string(),
+                status: ToolStatus::Found,
+            }],
+            env: vec![EnvResult {
+                name: "GITHUB_TOKEN".to_string(),
+                description: "GitHub API token".to_string(),
+                required: true,
+                status: EnvStatus::MissingRequired,
+            }],
+        };
+
+        let json = serde_json::to_string_pretty(&result).unwrap();
+        assert!(json.contains("\"tools\""));
+        assert!(json.contains("\"gh\""));
+        assert!(json.contains("\"env\""));
+        assert!(json.contains("GITHUB_TOKEN"));
+        assert!(json.contains("missing_required"));
+    }
+
+    #[test]
+    fn install_result_omits_empty_tools_and_env() {
+        let result = InstallResult {
+            resource_type: "agent".to_string(),
+            name: "debugger".to_string(),
+            version: "0.5.0".to_string(),
+            files: vec!["debugger.md".to_string()],
+            install_dir: ".claude/agents".to_string(),
+            tools: Vec::new(),
+            env: Vec::new(),
+        };
+
+        let json = serde_json::to_string_pretty(&result).unwrap();
+        assert!(!json.contains("\"tools\""), "empty tools should be omitted");
+        assert!(!json.contains("\"env\""), "empty env should be omitted");
+    }
+
+    #[test]
+    fn print_tool_result_all_statuses() {
+        let statuses = vec![
+            ToolStatus::Found,
+            ToolStatus::Installed,
+            ToolStatus::Declined,
+            ToolStatus::Failed("error msg".to_string()),
+            ToolStatus::NoCommand,
+            ToolStatus::Skipped,
+        ];
+        for status in statuses {
+            print_tool_result(&ToolResult {
+                name: "test".to_string(),
+                description: "test tool".to_string(),
+                status,
+            });
+        }
+    }
+
+    #[test]
+    fn print_env_result_all_statuses() {
+        let statuses = vec![
+            EnvStatus::FoundInEnv,
+            EnvStatus::FoundInSettings,
+            EnvStatus::MissingRequired,
+            EnvStatus::MissingOptional,
+        ];
+        for status in statuses {
+            print_env_result(&EnvResult {
+                name: "TEST_VAR".to_string(),
+                description: "test".to_string(),
+                required: true,
+                status,
+            });
+        }
     }
 }

--- a/crates/relava-cli/src/main.rs
+++ b/crates/relava-cli/src/main.rs
@@ -40,6 +40,7 @@ fn main() {
             version,
             save: _save,
             global,
+            yes,
         } => {
             let Some(name) = name else {
                 eprintln!("missing resource name. Usage: relava install <type> <name>");
@@ -65,6 +66,7 @@ fn main() {
                 global,
                 json: cli.json,
                 verbose: cli.verbose,
+                yes,
             };
 
             match install::run(&opts) {

--- a/crates/relava-core/Cargo.toml
+++ b/crates/relava-core/Cargo.toml
@@ -15,3 +15,6 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 sha2 = { workspace = true }
 toml.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/relava-core/src/env_check.rs
+++ b/crates/relava-core/src/env_check.rs
@@ -1,0 +1,343 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::manifest::EnvSpec;
+
+/// Status of an env var check.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvStatus {
+    /// Found in the process environment.
+    FoundInEnv,
+    /// Found in `.claude/settings.json` `env` entries.
+    FoundInSettings,
+    /// Missing and required.
+    MissingRequired,
+    /// Missing but optional.
+    MissingOptional,
+}
+
+/// Result of checking a single env var.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct EnvResult {
+    pub name: String,
+    pub description: String,
+    pub required: bool,
+    pub status: EnvStatus,
+}
+
+/// Read env vars from `.claude/settings.json`.
+///
+/// Looks for the `env` key at the top level, which maps var names to values.
+/// Returns an empty map if the file is missing or has no `env` key.
+/// Warns on IO errors (other than not-found) and JSON parse failures.
+fn read_settings_env(project_root: &Path) -> BTreeMap<String, String> {
+    let settings_path = project_root.join(".claude").join("settings.json");
+
+    let content = match std::fs::read_to_string(&settings_path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return BTreeMap::new(),
+        Err(e) => {
+            eprintln!("warning: cannot read {}: {e}", settings_path.display());
+            return BTreeMap::new();
+        }
+    };
+
+    let parsed: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("warning: failed to parse {}: {e}", settings_path.display());
+            return BTreeMap::new();
+        }
+    };
+
+    parsed
+        .get("env")
+        .and_then(|v| v.as_object())
+        .map(|env_obj| {
+            env_obj
+                .iter()
+                .filter_map(|(k, v)| Some((k.clone(), v.as_str()?.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Check all declared env vars against the process environment and settings.json.
+///
+/// Returns a result per env var. Missing vars produce warnings, not errors.
+pub fn check_env_vars(
+    env_specs: &BTreeMap<String, EnvSpec>,
+    project_root: &Path,
+) -> Vec<EnvResult> {
+    let settings_env = read_settings_env(project_root);
+    let mut results = Vec::new();
+
+    for (name, spec) in env_specs {
+        let in_process = std::env::var_os(name).is_some();
+        let in_settings = settings_env.contains_key(name);
+
+        let status = if in_process {
+            EnvStatus::FoundInEnv
+        } else if in_settings {
+            EnvStatus::FoundInSettings
+        } else if spec.required {
+            EnvStatus::MissingRequired
+        } else {
+            EnvStatus::MissingOptional
+        };
+
+        results.push(EnvResult {
+            name: name.clone(),
+            description: spec.description.clone(),
+            required: spec.required,
+            status,
+        });
+    }
+
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn temp_dir() -> TempDir {
+        TempDir::new().expect("failed to create temp dir")
+    }
+
+    fn make_settings(dir: &Path, env_json: &str) {
+        let claude_dir = dir.join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        let settings = format!(r#"{{"env": {env_json}}}"#);
+        fs::write(claude_dir.join("settings.json"), settings).unwrap();
+    }
+
+    #[test]
+    fn check_missing_required() {
+        let project = temp_dir();
+        let mut specs = BTreeMap::new();
+        specs.insert(
+            "RELAVA_TEST_MISSING_VAR_12345".to_string(),
+            EnvSpec {
+                required: true,
+                description: "test var".to_string(),
+            },
+        );
+
+        let results = check_env_vars(&specs, project.path());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, EnvStatus::MissingRequired);
+        assert!(results[0].required);
+    }
+
+    #[test]
+    fn check_missing_optional() {
+        let project = temp_dir();
+        let mut specs = BTreeMap::new();
+        specs.insert(
+            "RELAVA_TEST_OPTIONAL_VAR_12345".to_string(),
+            EnvSpec {
+                required: false,
+                description: "optional var".to_string(),
+            },
+        );
+
+        let results = check_env_vars(&specs, project.path());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, EnvStatus::MissingOptional);
+    }
+
+    #[test]
+    fn check_found_in_process_env() {
+        let project = temp_dir();
+        // PATH is always set
+        let mut specs = BTreeMap::new();
+        specs.insert(
+            "PATH".to_string(),
+            EnvSpec {
+                required: true,
+                description: "system path".to_string(),
+            },
+        );
+
+        let results = check_env_vars(&specs, project.path());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, EnvStatus::FoundInEnv);
+    }
+
+    #[test]
+    fn check_found_in_settings_json() {
+        let project = temp_dir();
+        make_settings(
+            project.path(),
+            r#"{"RELAVA_TEST_SETTINGS_VAR_12345": "value"}"#,
+        );
+
+        let mut specs = BTreeMap::new();
+        specs.insert(
+            "RELAVA_TEST_SETTINGS_VAR_12345".to_string(),
+            EnvSpec {
+                required: true,
+                description: "from settings".to_string(),
+            },
+        );
+
+        let results = check_env_vars(&specs, project.path());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, EnvStatus::FoundInSettings);
+    }
+
+    #[test]
+    fn check_process_env_takes_precedence_over_settings() {
+        let project = temp_dir();
+        // PATH exists in process env AND we put it in settings
+        make_settings(project.path(), r#"{"PATH": "override"}"#);
+
+        let mut specs = BTreeMap::new();
+        specs.insert(
+            "PATH".to_string(),
+            EnvSpec {
+                required: true,
+                description: "system path".to_string(),
+            },
+        );
+
+        let results = check_env_vars(&specs, project.path());
+        assert_eq!(results[0].status, EnvStatus::FoundInEnv);
+    }
+
+    #[test]
+    fn check_no_settings_file() {
+        let project = temp_dir();
+        // No .claude/settings.json at all
+        let mut specs = BTreeMap::new();
+        specs.insert(
+            "RELAVA_TEST_NO_SETTINGS_VAR_12345".to_string(),
+            EnvSpec {
+                required: true,
+                description: "missing".to_string(),
+            },
+        );
+
+        let results = check_env_vars(&specs, project.path());
+        assert_eq!(results[0].status, EnvStatus::MissingRequired);
+    }
+
+    #[test]
+    fn check_invalid_settings_json() {
+        let project = temp_dir();
+        let claude_dir = project.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(claude_dir.join("settings.json"), "not json").unwrap();
+
+        let mut specs = BTreeMap::new();
+        specs.insert(
+            "RELAVA_TEST_BAD_JSON_VAR_12345".to_string(),
+            EnvSpec {
+                required: true,
+                description: "missing".to_string(),
+            },
+        );
+
+        let results = check_env_vars(&specs, project.path());
+        assert_eq!(results[0].status, EnvStatus::MissingRequired);
+    }
+
+    #[test]
+    fn check_settings_no_env_key() {
+        let project = temp_dir();
+        let claude_dir = project.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(claude_dir.join("settings.json"), r#"{"other": "key"}"#).unwrap();
+
+        let mut specs = BTreeMap::new();
+        specs.insert(
+            "RELAVA_TEST_NO_ENV_KEY_VAR_12345".to_string(),
+            EnvSpec {
+                required: true,
+                description: "missing".to_string(),
+            },
+        );
+
+        let results = check_env_vars(&specs, project.path());
+        assert_eq!(results[0].status, EnvStatus::MissingRequired);
+    }
+
+    #[test]
+    fn check_empty_specs() {
+        let project = temp_dir();
+        let specs = BTreeMap::new();
+        let results = check_env_vars(&specs, project.path());
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn check_multiple_vars_mixed() {
+        let project = temp_dir();
+        make_settings(
+            project.path(),
+            r#"{"RELAVA_TEST_IN_SETTINGS_VAR_12345": "val"}"#,
+        );
+
+        let mut specs = BTreeMap::new();
+        // This one is in process env
+        specs.insert(
+            "PATH".to_string(),
+            EnvSpec {
+                required: true,
+                description: "path".to_string(),
+            },
+        );
+        // This one is in settings
+        specs.insert(
+            "RELAVA_TEST_IN_SETTINGS_VAR_12345".to_string(),
+            EnvSpec {
+                required: true,
+                description: "in settings".to_string(),
+            },
+        );
+        // This one is missing and required
+        specs.insert(
+            "RELAVA_TEST_TOTALLY_MISSING_VAR_12345".to_string(),
+            EnvSpec {
+                required: true,
+                description: "missing".to_string(),
+            },
+        );
+        // This one is missing but optional
+        specs.insert(
+            "RELAVA_TEST_OPTIONAL_MISSING_VAR_12345".to_string(),
+            EnvSpec {
+                required: false,
+                description: "optional".to_string(),
+            },
+        );
+
+        let results = check_env_vars(&specs, project.path());
+        assert_eq!(results.len(), 4);
+
+        let path_result = results.iter().find(|r| r.name == "PATH").unwrap();
+        assert_eq!(path_result.status, EnvStatus::FoundInEnv);
+
+        let settings_result = results
+            .iter()
+            .find(|r| r.name == "RELAVA_TEST_IN_SETTINGS_VAR_12345")
+            .unwrap();
+        assert_eq!(settings_result.status, EnvStatus::FoundInSettings);
+
+        let missing_req = results
+            .iter()
+            .find(|r| r.name == "RELAVA_TEST_TOTALLY_MISSING_VAR_12345")
+            .unwrap();
+        assert_eq!(missing_req.status, EnvStatus::MissingRequired);
+
+        let missing_opt = results
+            .iter()
+            .find(|r| r.name == "RELAVA_TEST_OPTIONAL_MISSING_VAR_12345")
+            .unwrap();
+        assert_eq!(missing_opt.status, EnvStatus::MissingOptional);
+    }
+}

--- a/crates/relava-core/src/lib.rs
+++ b/crates/relava-core/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod cache;
+pub mod env_check;
 pub mod manifest;
 pub mod registry;
 pub mod store;
+pub mod tools;
 pub mod validate;
 pub mod version;

--- a/crates/relava-core/src/tools.rs
+++ b/crates/relava-core/src/tools.rs
@@ -1,0 +1,376 @@
+use std::collections::BTreeMap;
+use std::process::Command;
+
+use crate::manifest::ToolSpec;
+
+/// Status of a tool check/install attempt.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolStatus {
+    /// Already present on PATH.
+    Found,
+    /// Successfully installed.
+    Installed,
+    /// User declined the install prompt.
+    Declined,
+    /// Install command failed (with stderr output).
+    Failed(String),
+    /// No install command for this OS.
+    NoCommand,
+    /// Skipped (not found, but `--yes` was not set and we're non-interactive).
+    Skipped,
+}
+
+/// Result of checking/installing a single tool.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ToolResult {
+    pub name: String,
+    pub description: String,
+    pub status: ToolStatus,
+}
+
+/// Detect the current OS as a key matching the `install` map in `ToolSpec`.
+///
+/// Returns `"macos"`, `"linux"`, or `"windows"`.
+pub fn detect_os() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        "linux"
+    }
+}
+
+/// Check if a binary exists on PATH.
+///
+/// Uses `which` on Unix-like systems and `where` on Windows.
+pub fn tool_on_path(name: &str) -> bool {
+    let cmd = if cfg!(target_os = "windows") {
+        "where"
+    } else {
+        "which"
+    };
+    match Command::new(cmd)
+        .arg(name)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+    {
+        Ok(status) => status.success(),
+        Err(e) => {
+            eprintln!("warning: failed to run `{cmd}`: {e}");
+            false
+        }
+    }
+}
+
+/// Run an install command string via the system shell.
+///
+/// Returns `Ok(())` on success, `Err(stderr)` on failure.
+pub fn run_install_command(command: &str) -> Result<(), String> {
+    let (shell, flag) = if cfg!(target_os = "windows") {
+        ("cmd", "/C")
+    } else {
+        ("sh", "-c")
+    };
+
+    let output = Command::new(shell)
+        .args([flag, command])
+        .output()
+        .map_err(|e| format!("failed to execute install command: {e}"))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let msg = stderr.trim();
+        if msg.is_empty() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            Err(stdout.trim().to_string())
+        } else {
+            Err(msg.to_string())
+        }
+    }
+}
+
+/// Prompt callback type: given a prompt string, return true to proceed.
+pub type PromptFn = Box<dyn Fn(&str) -> bool>;
+
+/// Determine the status of a single tool: found, install attempted, or skipped.
+fn check_single_tool(
+    name: &str,
+    spec: &ToolSpec,
+    os: &str,
+    auto_yes: bool,
+    prompt_fn: Option<&PromptFn>,
+) -> ToolStatus {
+    if tool_on_path(name) {
+        return ToolStatus::Found;
+    }
+
+    let install_cmd = match spec.install.get(os) {
+        Some(cmd) => cmd,
+        None => return ToolStatus::NoCommand,
+    };
+
+    let should_install = if auto_yes {
+        true
+    } else {
+        match prompt_fn {
+            Some(f) => f(&format!("Install with: {install_cmd}? [Y/n]")),
+            None => return ToolStatus::Skipped,
+        }
+    };
+
+    if !should_install {
+        return ToolStatus::Declined;
+    }
+
+    eprintln!("  running: {install_cmd}");
+    match run_install_command(install_cmd) {
+        Ok(()) => ToolStatus::Installed,
+        Err(e) => ToolStatus::Failed(e),
+    }
+}
+
+/// Check and optionally install all declared tools.
+///
+/// - `tools`: the `metadata.relava.tools` map from the skill's frontmatter
+/// - `auto_yes`: if true, skip prompts and auto-install
+/// - `prompt_fn`: callback for interactive prompts (only called when `auto_yes` is false)
+///
+/// Returns a result per tool. Tool failures are non-fatal.
+pub fn check_and_install_tools(
+    tools: &BTreeMap<String, ToolSpec>,
+    auto_yes: bool,
+    prompt_fn: Option<&PromptFn>,
+) -> Vec<ToolResult> {
+    let os = detect_os();
+
+    tools
+        .iter()
+        .map(|(name, spec)| {
+            let status = check_single_tool(name, spec, os, auto_yes, prompt_fn);
+            ToolResult {
+                name: name.clone(),
+                description: spec.description.clone(),
+                status,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_os_returns_known_value() {
+        let os = detect_os();
+        assert!(
+            ["macos", "linux", "windows"].contains(&os),
+            "unexpected OS: {os}"
+        );
+    }
+
+    #[test]
+    fn tool_on_path_finds_common_tool() {
+        // `sh` is always available on Unix CI; `cmd` on Windows
+        if cfg!(target_os = "windows") {
+            assert!(tool_on_path("cmd"));
+        } else {
+            assert!(tool_on_path("sh"));
+        }
+    }
+
+    #[test]
+    fn tool_on_path_missing_tool() {
+        assert!(!tool_on_path("this-tool-definitely-does-not-exist-xyz"));
+    }
+
+    #[test]
+    fn check_tool_already_on_path() {
+        let mut tools = BTreeMap::new();
+        let existing = if cfg!(target_os = "windows") {
+            "cmd"
+        } else {
+            "sh"
+        };
+        tools.insert(
+            existing.to_string(),
+            ToolSpec {
+                description: "shell".to_string(),
+                install: BTreeMap::new(),
+            },
+        );
+
+        let results = check_and_install_tools(&tools, false, None);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, ToolStatus::Found);
+    }
+
+    #[test]
+    fn check_tool_missing_no_command_for_os() {
+        let mut tools = BTreeMap::new();
+        // Use an OS key that won't match
+        let mut install = BTreeMap::new();
+        install.insert("nonexistent-os".to_string(), "echo hello".to_string());
+        tools.insert(
+            "fake-tool-xyz".to_string(),
+            ToolSpec {
+                description: "fake".to_string(),
+                install,
+            },
+        );
+
+        let results = check_and_install_tools(&tools, false, None);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, ToolStatus::NoCommand);
+    }
+
+    #[test]
+    fn check_tool_missing_skipped_no_prompt() {
+        let mut tools = BTreeMap::new();
+        let os = detect_os();
+        let mut install = BTreeMap::new();
+        install.insert(os.to_string(), "echo installed".to_string());
+        tools.insert(
+            "fake-tool-xyz".to_string(),
+            ToolSpec {
+                description: "fake".to_string(),
+                install,
+            },
+        );
+
+        // No prompt function provided, non-interactive -> Skipped
+        let results = check_and_install_tools(&tools, false, None);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, ToolStatus::Skipped);
+    }
+
+    #[test]
+    fn check_tool_declined_by_user() {
+        let mut tools = BTreeMap::new();
+        let os = detect_os();
+        let mut install = BTreeMap::new();
+        install.insert(os.to_string(), "echo installed".to_string());
+        tools.insert(
+            "fake-tool-xyz".to_string(),
+            ToolSpec {
+                description: "fake".to_string(),
+                install,
+            },
+        );
+
+        let prompt: PromptFn = Box::new(|_| false);
+        let results = check_and_install_tools(&tools, false, Some(&prompt));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, ToolStatus::Declined);
+    }
+
+    #[test]
+    fn check_tool_auto_yes_installs() {
+        let mut tools = BTreeMap::new();
+        let os = detect_os();
+        let mut install = BTreeMap::new();
+        // Use a harmless command that succeeds
+        install.insert(os.to_string(), "echo ok".to_string());
+        tools.insert(
+            "fake-tool-xyz-auto".to_string(),
+            ToolSpec {
+                description: "fake".to_string(),
+                install,
+            },
+        );
+
+        let results = check_and_install_tools(&tools, true, None);
+        assert_eq!(results.len(), 1);
+        // Command succeeds, so tool is "installed" (even though it's just echo)
+        assert_eq!(results[0].status, ToolStatus::Installed);
+    }
+
+    #[test]
+    fn check_tool_install_failure() {
+        let mut tools = BTreeMap::new();
+        let os = detect_os();
+        let mut install = BTreeMap::new();
+        install.insert(os.to_string(), "false".to_string());
+        tools.insert(
+            "fake-tool-xyz-fail".to_string(),
+            ToolSpec {
+                description: "fake".to_string(),
+                install,
+            },
+        );
+
+        let results = check_and_install_tools(&tools, true, None);
+        assert_eq!(results.len(), 1);
+        assert!(matches!(results[0].status, ToolStatus::Failed(_)));
+    }
+
+    #[test]
+    fn run_install_command_success() {
+        assert!(run_install_command("echo hello").is_ok());
+    }
+
+    #[test]
+    fn run_install_command_failure() {
+        let cmd = if cfg!(target_os = "windows") {
+            "exit /b 1"
+        } else {
+            "false"
+        };
+        let result = run_install_command(cmd);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_tools_map() {
+        let tools = BTreeMap::new();
+        let results = check_and_install_tools(&tools, false, None);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn multiple_tools_mixed_status() {
+        let mut tools = BTreeMap::new();
+
+        // Tool that exists on PATH
+        let existing = if cfg!(target_os = "windows") {
+            "cmd"
+        } else {
+            "sh"
+        };
+        tools.insert(
+            existing.to_string(),
+            ToolSpec {
+                description: "shell".to_string(),
+                install: BTreeMap::new(),
+            },
+        );
+
+        // Tool that doesn't exist and has no command for this OS
+        let mut install = BTreeMap::new();
+        install.insert("nonexistent-os".to_string(), "echo hello".to_string());
+        tools.insert(
+            "zzz-nonexistent-tool".to_string(),
+            ToolSpec {
+                description: "missing".to_string(),
+                install,
+            },
+        );
+
+        let results = check_and_install_tools(&tools, false, None);
+        assert_eq!(results.len(), 2);
+
+        let found = results.iter().find(|r| r.name == existing).unwrap();
+        assert_eq!(found.status, ToolStatus::Found);
+
+        let missing = results
+            .iter()
+            .find(|r| r.name == "zzz-nonexistent-tool")
+            .unwrap();
+        assert_eq!(missing.status, ToolStatus::NoCommand);
+    }
+}


### PR DESCRIPTION
## Summary

- **Tool installation (Item 10a):** After writing skill files, parses `metadata.relava.tools` from SKILL.md frontmatter. For each declared tool: checks PATH via `which`/`where`, detects OS, prompts user for install confirmation (skip with `--yes`), executes OS-specific install command. Reports per-tool status: `found`, `installed`, `skipped`, `failed`, `declined`, `no_command`. Failures are non-fatal.
- **Env var checking (Item 10b):** Parses `metadata.relava.env` from frontmatter. Checks each var against process environment AND `.claude/settings.json` `env` entries. Missing required vars produce clear warnings with guidance on where to set them.
- **`--yes` / `-y` flag:** Auto-accept tool install prompts without interaction.
- **JSON output:** Tool and env var status included in `--json` output (omitted when empty for non-skill resources).

### New files
- `crates/relava-core/src/tools.rs` — Tool PATH detection, OS detection, install command execution
- `crates/relava-core/src/env_check.rs` — Env var validation against process env + settings.json

### Modified files
- `crates/relava-cli/src/install.rs` — Integrated post-install pipeline for skills
- `crates/relava-cli/src/cli.rs` — Added `--yes` flag
- `crates/relava-cli/src/main.rs` — Wired `--yes` through

## Test plan
- [x] 140 tests pass (27 CLI + 112 core + 1 server)
- [x] Tool found on PATH returns `Found` status
- [x] Tool missing with no OS command returns `NoCommand`
- [x] Tool declined by user returns `Declined`
- [x] Tool auto-installed with `--yes` returns `Installed`
- [x] Tool install failure returns `Failed` with stderr/stdout
- [x] Env var found in process env returns `FoundInEnv`
- [x] Env var found in settings.json returns `FoundInSettings`
- [x] Missing required env var returns `MissingRequired`
- [x] Missing optional env var returns `MissingOptional`
- [x] Non-skill resources skip post-install (empty tools/env)
- [x] Skill with no metadata returns empty results
- [x] Malformed frontmatter warns instead of failing
- [x] JSON output omits empty tools/env arrays
- [x] JSON output includes tool/env status when present
- [x] clippy clean, fmt clean

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)