### PR TITLE
Add REST endpoints for resources and versions CRUD

### DIFF
--- a/crates/relava-server/src/lib.rs
+++ b/crates/relava-server/src/lib.rs
@@ -1,26 +1,49 @@
+pub mod routes;
 pub mod store;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use axum::extract::State;
 use axum::{Json, Router, routing::get};
 use serde::Serialize;
 
+use store::db::SqliteResourceStore;
+
 /// Shared application state available to all handlers.
-#[derive(Clone)]
 pub struct AppState {
-    started_at: Instant,
+    pub started_at: Instant,
+    pub store: Mutex<SqliteResourceStore>,
 }
 
 /// Build the Relava API router with shared state.
-pub fn app() -> Router {
+///
+/// Opens (or creates) the SQLite database at `db_path` and wires all routes.
+pub fn app(db_path: &std::path::Path) -> Result<Router, store::StoreError> {
+    let store = SqliteResourceStore::open(db_path)?;
     let state = Arc::new(AppState {
         started_at: Instant::now(),
+        store: Mutex::new(store),
+    });
+
+    Ok(Router::new()
+        .route("/health", get(health))
+        .nest("/api/v1", routes::resource_routes())
+        .with_state(state))
+}
+
+/// Build a test router with an in-memory SQLite store (for testing only).
+#[cfg(test)]
+pub fn app_in_memory() -> Router {
+    let store = SqliteResourceStore::open_in_memory().unwrap();
+    let state = Arc::new(AppState {
+        started_at: Instant::now(),
+        store: Mutex::new(store),
     });
 
     Router::new()
         .route("/health", get(health))
+        .nest("/api/v1", routes::resource_routes())
         .with_state(state)
 }
 
@@ -82,7 +105,7 @@ mod tests {
 
     /// Send a GET request to the given URI and return the response.
     async fn get(uri: &str) -> axum::response::Response {
-        app()
+        app_in_memory()
             .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
             .await
             .unwrap()

--- a/crates/relava-server/src/main.rs
+++ b/crates/relava-server/src/main.rs
@@ -1,5 +1,6 @@
 use std::process::ExitCode;
 
+use relava_server::store::RelavaDir;
 use tokio::net::TcpListener;
 
 #[tokio::main]
@@ -16,8 +17,29 @@ async fn main() -> ExitCode {
         }
     };
 
+    // Set up the ~/.relava/ directory structure and open the database.
+    let relava_dir = match RelavaDir::default_location() {
+        Some(d) => d,
+        None => {
+            eprintln!("[relava-server] cannot determine home directory");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if let Err(e) = relava_dir.ensure_dirs() {
+        eprintln!("[relava-server] failed to create data directories: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    let app = match relava_server::app(&relava_dir.db_path()) {
+        Ok(app) => app,
+        Err(e) => {
+            eprintln!("[relava-server] failed to open database: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
     let addr = format!("{host}:{port}");
-    let app = relava_server::app();
 
     let listener = match TcpListener::bind(&addr).await {
         Ok(l) => l,

--- a/crates/relava-server/src/routes.rs
+++ b/crates/relava-server/src/routes.rs
@@ -1,0 +1,816 @@
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::{Json, Router, routing::get};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::store::db::SqliteResourceStore;
+use crate::store::models::{Resource, Version};
+use crate::store::traits::{ResourceStore, StoreError};
+use relava_types::validate::{ResourceType, validate_slug, validate_version};
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+/// Consistent JSON error response returned by all endpoints.
+#[derive(Debug, Serialize)]
+struct ApiError {
+    error: String,
+}
+
+impl ApiError {
+    fn new(msg: impl Into<String>) -> Self {
+        Self { error: msg.into() }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, Json(self)).into_response()
+    }
+}
+
+/// Convert a `StoreError` into an HTTP response with the correct status code.
+///
+/// Internal errors (Database, Io) are logged but not exposed to clients.
+fn store_err(e: StoreError) -> Response {
+    let (status, msg) = match &e {
+        StoreError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
+        StoreError::AlreadyExists(msg) => (StatusCode::CONFLICT, msg.clone()),
+        StoreError::Database(msg) => {
+            eprintln!("[relava-server] database error: {msg}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal server error".to_string(),
+            )
+        }
+        StoreError::Io(err) => {
+            eprintln!("[relava-server] I/O error: {err}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal server error".to_string(),
+            )
+        }
+    };
+    (status, Json(ApiError::new(msg))).into_response()
+}
+
+/// Acquire the store lock, returning 500 if the Mutex is poisoned.
+#[allow(clippy::result_large_err)]
+fn acquire_store(
+    state: &AppState,
+) -> Result<std::sync::MutexGuard<'_, SqliteResourceStore>, Response> {
+    state.store.lock().map_err(|_| {
+        eprintln!("[relava-server] store mutex poisoned");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError::new("internal server error")),
+        )
+            .into_response()
+    })
+}
+
+/// Return a 422 Unprocessable Entity with a validation message.
+fn validation_err(msg: impl Into<String>) -> Response {
+    (
+        StatusCode::UNPROCESSABLE_ENTITY,
+        Json(ApiError::new(msg.into())),
+    )
+        .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Path / query helpers
+// ---------------------------------------------------------------------------
+
+/// Parse and validate a resource type from the URL path segment.
+#[allow(clippy::result_large_err)]
+fn parse_resource_type(s: &str) -> Result<ResourceType, Response> {
+    ResourceType::from_str(s).map_err(|_| {
+        validation_err(format!(
+            "invalid resource type '{s}': must be skill, agent, command, or rule"
+        ))
+    })
+}
+
+/// Parse and validate a resource name (slug) from the URL path segment.
+#[allow(clippy::result_large_err)]
+fn parse_name(s: &str) -> Result<(), Response> {
+    validate_slug(s).map_err(|e| validation_err(e.to_string()))
+}
+
+/// Parse and validate a semver version string from the URL path segment.
+#[allow(clippy::result_large_err)]
+fn parse_version(s: &str) -> Result<(), Response> {
+    validate_version(s)
+        .map(|_| ())
+        .map_err(|e| validation_err(e.to_string()))
+}
+
+/// Validate both resource type and name from URL path segments.
+#[allow(clippy::result_large_err)]
+fn validate_resource_path(rtype: &str, name: &str) -> Result<ResourceType, Response> {
+    let rt = parse_resource_type(rtype)?;
+    parse_name(name)?;
+    Ok(rt)
+}
+
+// ---------------------------------------------------------------------------
+// JSON response types
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ResourceResponse {
+    name: String,
+    #[serde(rename = "type")]
+    resource_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    latest_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    updated_at: Option<String>,
+}
+
+impl From<Resource> for ResourceResponse {
+    fn from(r: Resource) -> Self {
+        Self {
+            name: r.name,
+            resource_type: r.resource_type,
+            description: r.description,
+            latest_version: r.latest_version,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct VersionResponse {
+    version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    checksum: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    published_at: Option<String>,
+}
+
+impl From<Version> for VersionResponse {
+    fn from(v: Version) -> Self {
+        Self {
+            version: v.version,
+            checksum: v.checksum,
+            published_at: v.published_at,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ListQuery {
+    #[serde(rename = "type")]
+    resource_type: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CreateBody {
+    description: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/resources?type=skill
+async fn list_resources(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ListQuery>,
+) -> Response {
+    let rt = match &query.resource_type {
+        Some(t) => match parse_resource_type(t) {
+            Ok(rt) => Some(rt),
+            Err(resp) => return resp,
+        },
+        None => None,
+    };
+
+    let store = match acquire_store(&state) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    match store.list_resources(rt) {
+        Ok(resources) => {
+            let body: Vec<ResourceResponse> = resources.into_iter().map(Into::into).collect();
+            Json(body).into_response()
+        }
+        Err(e) => store_err(e),
+    }
+}
+
+/// GET /api/v1/resources/:type/:name
+async fn get_resource(
+    State(state): State<Arc<AppState>>,
+    Path((rtype, name)): Path<(String, String)>,
+) -> Response {
+    let rt = match validate_resource_path(&rtype, &name) {
+        Ok(rt) => rt,
+        Err(resp) => return resp,
+    };
+
+    let store = match acquire_store(&state) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    match store.get_resource(None, &name, rt) {
+        Ok(resource) => Json(ResourceResponse::from(resource)).into_response(),
+        Err(e) => store_err(e),
+    }
+}
+
+/// POST /api/v1/resources/:type/:name
+async fn create_resource(
+    State(state): State<Arc<AppState>>,
+    Path((rtype, name)): Path<(String, String)>,
+    Json(body): Json<CreateBody>,
+) -> Response {
+    let rt = match validate_resource_path(&rtype, &name) {
+        Ok(rt) => rt,
+        Err(resp) => return resp,
+    };
+
+    let resource = Resource {
+        id: 0,
+        scope: None,
+        name: name.clone(),
+        resource_type: rt.to_string(),
+        description: body.description,
+        latest_version: None,
+        metadata_json: None,
+        updated_at: None,
+    };
+
+    let store = match acquire_store(&state) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    match store.create_resource(&resource) {
+        Ok(created) => (StatusCode::CREATED, Json(ResourceResponse::from(created))).into_response(),
+        Err(e) => store_err(e),
+    }
+}
+
+/// DELETE /api/v1/resources/:type/:name
+async fn delete_resource(
+    State(state): State<Arc<AppState>>,
+    Path((rtype, name)): Path<(String, String)>,
+) -> Response {
+    let rt = match validate_resource_path(&rtype, &name) {
+        Ok(rt) => rt,
+        Err(resp) => return resp,
+    };
+
+    let store = match acquire_store(&state) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    match store.delete_resource(None, &name, rt) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => store_err(e),
+    }
+}
+
+/// GET /api/v1/resources/:type/:name/versions
+async fn list_versions(
+    State(state): State<Arc<AppState>>,
+    Path((rtype, name)): Path<(String, String)>,
+) -> Response {
+    let rt = match validate_resource_path(&rtype, &name) {
+        Ok(rt) => rt,
+        Err(resp) => return resp,
+    };
+
+    let store = match acquire_store(&state) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let resource = match store.get_resource(None, &name, rt) {
+        Ok(r) => r,
+        Err(e) => return store_err(e),
+    };
+
+    match store.list_versions(resource.id) {
+        Ok(versions) => {
+            let body: Vec<VersionResponse> = versions.into_iter().map(Into::into).collect();
+            Json(body).into_response()
+        }
+        Err(e) => store_err(e),
+    }
+}
+
+/// GET /api/v1/resources/:type/:name/versions/:version
+async fn get_version(
+    State(state): State<Arc<AppState>>,
+    Path((rtype, name, version)): Path<(String, String, String)>,
+) -> Response {
+    let rt = match validate_resource_path(&rtype, &name) {
+        Ok(rt) => rt,
+        Err(resp) => return resp,
+    };
+    if let Err(resp) = parse_version(&version) {
+        return resp;
+    }
+
+    let store = match acquire_store(&state) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let resource = match store.get_resource(None, &name, rt) {
+        Ok(r) => r,
+        Err(e) => return store_err(e),
+    };
+
+    match store.get_version(resource.id, &version) {
+        Ok(v) => Json(VersionResponse::from(v)).into_response(),
+        Err(e) => store_err(e),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/// Build the `/api/v1` resource routes.
+pub fn resource_routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/resources", get(list_resources))
+        .route(
+            "/resources/{type}/{name}",
+            get(get_resource)
+                .post(create_resource)
+                .delete(delete_resource),
+        )
+        .route("/resources/{type}/{name}/versions", get(list_versions))
+        .route(
+            "/resources/{type}/{name}/versions/{version}",
+            get(get_version),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::db::SqliteResourceStore;
+    use axum::body::Body;
+    use axum::http::Request;
+    use std::sync::Mutex;
+    use tower::ServiceExt;
+
+    fn test_app() -> Router {
+        crate::app_in_memory()
+    }
+
+    /// Send a request and return the response.
+    async fn send(
+        app: Router,
+        method: &str,
+        uri: &str,
+        body: Option<&str>,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder().method(method).uri(uri);
+        let body = if let Some(json) = body {
+            builder = builder.header("content-type", "application/json");
+            Body::from(json.to_string())
+        } else {
+            Body::empty()
+        };
+        app.oneshot(builder.body(body).unwrap()).await.unwrap()
+    }
+
+    /// Parse response body as JSON.
+    async fn json_body(response: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    // -- List resources --
+
+    #[tokio::test]
+    async fn list_resources_empty() {
+        let app = test_app();
+        let resp = send(app, "GET", "/api/v1/resources", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn list_resources_with_type_filter() {
+        let app = test_app();
+        // Create a skill
+        let resp = send(
+            app.clone(),
+            "POST",
+            "/api/v1/resources/skill/denden",
+            Some(r#"{"description":"a skill"}"#),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // Filter by skill — should find it
+        let resp = send(app.clone(), "GET", "/api/v1/resources?type=skill", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body.as_array().unwrap().len(), 1);
+
+        // Filter by agent — should be empty
+        let resp = send(app, "GET", "/api/v1/resources?type=agent", None).await;
+        let body = json_body(resp).await;
+        assert_eq!(body.as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn list_resources_invalid_type_filter() {
+        let app = test_app();
+        let resp = send(app, "GET", "/api/v1/resources?type=invalid", None).await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    // -- Get resource --
+
+    #[tokio::test]
+    async fn get_resource_not_found() {
+        let app = test_app();
+        let resp = send(app, "GET", "/api/v1/resources/skill/nonexistent", None).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = json_body(resp).await;
+        assert!(body["error"].as_str().unwrap().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn get_resource_returns_metadata() {
+        let app = test_app();
+        send(
+            app.clone(),
+            "POST",
+            "/api/v1/resources/skill/denden",
+            Some(r#"{"description":"Communication skill"}"#),
+        )
+        .await;
+
+        let resp = send(app, "GET", "/api/v1/resources/skill/denden", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body["name"], "denden");
+        assert_eq!(body["type"], "skill");
+        assert_eq!(body["description"], "Communication skill");
+    }
+
+    // -- Create resource --
+
+    #[tokio::test]
+    async fn create_resource_success() {
+        let app = test_app();
+        let resp = send(
+            app,
+            "POST",
+            "/api/v1/resources/agent/debugger",
+            Some(r#"{"description":"Debug agent"}"#),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = json_body(resp).await;
+        assert_eq!(body["name"], "debugger");
+        assert_eq!(body["type"], "agent");
+        assert_eq!(body["description"], "Debug agent");
+    }
+
+    #[tokio::test]
+    async fn create_resource_duplicate_returns_409() {
+        let app = test_app();
+        send(
+            app.clone(),
+            "POST",
+            "/api/v1/resources/skill/denden",
+            Some(r#"{"description":"first"}"#),
+        )
+        .await;
+
+        let resp = send(
+            app,
+            "POST",
+            "/api/v1/resources/skill/denden",
+            Some(r#"{"description":"second"}"#),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn create_resource_invalid_type() {
+        let app = test_app();
+        let resp = send(
+            app,
+            "POST",
+            "/api/v1/resources/invalid/denden",
+            Some(r#"{"description":"test"}"#),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn create_resource_invalid_slug() {
+        let app = test_app();
+        let resp = send(
+            app,
+            "POST",
+            "/api/v1/resources/skill/INVALID",
+            Some(r#"{"description":"test"}"#),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    // -- Delete resource --
+
+    #[tokio::test]
+    async fn delete_resource_success() {
+        let app = test_app();
+        send(
+            app.clone(),
+            "POST",
+            "/api/v1/resources/skill/denden",
+            Some(r#"{"description":"test"}"#),
+        )
+        .await;
+
+        let resp = send(
+            app.clone(),
+            "DELETE",
+            "/api/v1/resources/skill/denden",
+            None,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        // Confirm it's gone
+        let resp = send(app, "GET", "/api/v1/resources/skill/denden", None).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn delete_resource_not_found() {
+        let app = test_app();
+        let resp = send(app, "DELETE", "/api/v1/resources/skill/nonexistent", None).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // -- List versions --
+
+    #[tokio::test]
+    async fn list_versions_empty() {
+        let app = test_app();
+        send(
+            app.clone(),
+            "POST",
+            "/api/v1/resources/skill/denden",
+            Some(r#"{"description":"test"}"#),
+        )
+        .await;
+
+        let resp = send(app, "GET", "/api/v1/resources/skill/denden/versions", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn list_versions_resource_not_found() {
+        let app = test_app();
+        let resp = send(
+            app,
+            "GET",
+            "/api/v1/resources/skill/nonexistent/versions",
+            None,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // -- Get version --
+
+    #[tokio::test]
+    async fn get_version_not_found() {
+        let app = test_app();
+        send(
+            app.clone(),
+            "POST",
+            "/api/v1/resources/skill/denden",
+            Some(r#"{"description":"test"}"#),
+        )
+        .await;
+
+        let resp = send(
+            app,
+            "GET",
+            "/api/v1/resources/skill/denden/versions/1.0.0",
+            None,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_version_invalid_semver() {
+        let app = test_app();
+        let resp = send(
+            app,
+            "GET",
+            "/api/v1/resources/skill/denden/versions/abc",
+            None,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    // -- Versions via publish (integration) --
+
+    #[tokio::test]
+    async fn list_and_get_versions_after_publish() {
+        // Build a test app with a pre-populated store (simulates `relava publish`).
+        let store = SqliteResourceStore::open_in_memory().unwrap();
+        let resource = crate::store::models::Resource {
+            id: 0,
+            scope: None,
+            name: "denden".to_string(),
+            resource_type: "skill".to_string(),
+            description: Some("test".to_string()),
+            latest_version: None,
+            metadata_json: None,
+            updated_at: None,
+        };
+        let version = crate::store::models::Version {
+            id: 0,
+            resource_id: 0,
+            version: "1.0.0".to_string(),
+            store_path: Some("skills/denden/1.0.0".to_string()),
+            checksum: Some("abc123".to_string()),
+            manifest_json: None,
+            published_by: None,
+            published_at: None,
+        };
+        store.publish(&resource, &version).unwrap();
+
+        let state = Arc::new(AppState {
+            started_at: std::time::Instant::now(),
+            store: Mutex::new(store),
+        });
+        let app = Router::new()
+            .nest("/api/v1", resource_routes())
+            .with_state(state);
+
+        // List versions
+        let resp = send(
+            app.clone(),
+            "GET",
+            "/api/v1/resources/skill/denden/versions",
+            None,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        let versions = body.as_array().unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["version"], "1.0.0");
+        assert_eq!(versions[0]["checksum"], "abc123");
+
+        // Get specific version
+        let resp = send(
+            app,
+            "GET",
+            "/api/v1/resources/skill/denden/versions/1.0.0",
+            None,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body["version"], "1.0.0");
+    }
+
+    // -- Additional edge-case tests --
+
+    #[tokio::test]
+    #[allow(clippy::items_after_statements)]
+    async fn create_resource_malformed_json_returns_error() {
+        let app = test_app();
+        // Send invalid JSON body
+        let resp = send(
+            app,
+            "POST",
+            "/api/v1/resources/skill/denden",
+            Some("not json at all"),
+        )
+        .await;
+        // Axum returns 400 Bad Request for malformed JSON
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn create_resource_empty_body_succeeds() {
+        let app = test_app();
+        // Empty JSON object — description is optional
+        let resp = send(app, "POST", "/api/v1/resources/skill/denden", Some("{}")).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn list_resources_mixed_types() {
+        let app = test_app();
+        send(
+            app.clone(),
+            "POST",
+            "/api/v1/resources/skill/denden",
+            Some(r#"{"description":"a skill"}"#),
+        )
+        .await;
+        send(
+            app.clone(),
+            "POST",
+            "/api/v1/resources/agent/debugger",
+            Some(r#"{"description":"an agent"}"#),
+        )
+        .await;
+
+        // Without type filter — returns both
+        let resp = send(app, "GET", "/api/v1/resources", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body.as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn delete_resource_also_deletes_versions() {
+        // Build a pre-populated store with a resource and versions.
+        let store = SqliteResourceStore::open_in_memory().unwrap();
+        let resource = crate::store::models::Resource {
+            id: 0,
+            scope: None,
+            name: "denden".to_string(),
+            resource_type: "skill".to_string(),
+            description: Some("test".to_string()),
+            latest_version: None,
+            metadata_json: None,
+            updated_at: None,
+        };
+        store
+            .publish(
+                &resource,
+                &crate::store::models::Version {
+                    id: 0,
+                    resource_id: 0,
+                    version: "1.0.0".to_string(),
+                    store_path: None,
+                    checksum: None,
+                    manifest_json: None,
+                    published_by: None,
+                    published_at: None,
+                },
+            )
+            .unwrap();
+
+        let state = Arc::new(AppState {
+            started_at: std::time::Instant::now(),
+            store: Mutex::new(store),
+        });
+        let app = Router::new()
+            .nest("/api/v1", resource_routes())
+            .with_state(state);
+
+        // Verify version exists
+        let resp = send(
+            app.clone(),
+            "GET",
+            "/api/v1/resources/skill/denden/versions",
+            None,
+        )
+        .await;
+        assert_eq!(json_body(resp).await.as_array().unwrap().len(), 1);
+
+        // Delete the resource
+        let resp = send(
+            app.clone(),
+            "DELETE",
+            "/api/v1/resources/skill/denden",
+            None,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        // Verify resource and versions are gone
+        let resp = send(app, "GET", "/api/v1/resources/skill/denden", None).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/relava-server/src/store/db.rs
+++ b/crates/relava-server/src/store/db.rs
@@ -174,6 +174,121 @@ impl ResourceStore for SqliteResourceStore {
             })
     }
 
+    fn list_resources(
+        &self,
+        resource_type: Option<ResourceType>,
+    ) -> Result<Vec<Resource>, StoreError> {
+        if let Some(rt) = resource_type {
+            let rt_str = rt.to_string();
+            self.query_resources(
+                "SELECT id, scope, name, type, description, latest_version, metadata_json, updated_at
+                 FROM resources
+                 WHERE type = ?1
+                 ORDER BY name",
+                &[&rt_str as &dyn ToSql],
+            )
+        } else {
+            self.query_resources(
+                "SELECT id, scope, name, type, description, latest_version, metadata_json, updated_at
+                 FROM resources
+                 ORDER BY name",
+                &[],
+            )
+        }
+    }
+
+    fn create_resource(&self, resource: &Resource) -> Result<Resource, StoreError> {
+        // Explicit duplicate check: SQLite UNIQUE treats NULL != NULL, so the
+        // constraint alone won't catch duplicates when scope is NULL.
+        let exists: bool = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM resources WHERE (scope IS ?1) AND name = ?2 AND type = ?3",
+                (&resource.scope, &resource.name, &resource.resource_type),
+                |row| row.get(0),
+            )
+            .map_err(db_err)?;
+
+        if exists {
+            return Err(StoreError::AlreadyExists(format!(
+                "{} '{}' already exists",
+                resource.resource_type, resource.name
+            )));
+        }
+
+        self.conn
+            .execute(
+                "INSERT INTO resources (scope, name, type, description, latest_version, metadata_json, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))",
+                (
+                    &resource.scope,
+                    &resource.name,
+                    &resource.resource_type,
+                    &resource.description,
+                    &resource.latest_version,
+                    &resource.metadata_json,
+                ),
+            )
+            .map_err(db_err)?;
+
+        let id = self.conn.last_insert_rowid();
+        self.conn
+            .query_row(
+                "SELECT id, scope, name, type, description, latest_version, metadata_json, updated_at
+                 FROM resources WHERE id = ?1",
+                [id],
+                resource_from_row,
+            )
+            .map_err(db_err)
+    }
+
+    fn delete_resource(
+        &self,
+        scope: Option<&str>,
+        name: &str,
+        resource_type: ResourceType,
+    ) -> Result<(), StoreError> {
+        let rt = resource_type.to_string();
+
+        // Use a transaction so versions and resource are deleted atomically.
+        self.conn.execute("BEGIN IMMEDIATE", []).map_err(db_err)?;
+
+        let result = (|| {
+            // Find the resource id (also validates existence).
+            let resource_id: i64 = self
+                .conn
+                .query_row(
+                    "SELECT id FROM resources WHERE (scope IS ?1) AND name = ?2 AND type = ?3",
+                    (scope, name, &rt),
+                    |row| row.get(0),
+                )
+                .map_err(|e| match e {
+                    rusqlite::Error::QueryReturnedNoRows => {
+                        StoreError::NotFound(format!("{resource_type} '{name}' not found"))
+                    }
+                    other => db_err(other),
+                })?;
+
+            // Delete all versions first, then the resource.
+            self.conn
+                .execute("DELETE FROM versions WHERE resource_id = ?1", [resource_id])
+                .map_err(db_err)?;
+            self.conn
+                .execute("DELETE FROM resources WHERE id = ?1", [resource_id])
+                .map_err(db_err)?;
+
+            Ok(())
+        })();
+
+        if result.is_ok() {
+            self.conn.execute("COMMIT", []).map_err(db_err)?;
+        } else {
+            let _ = self.conn.execute("ROLLBACK", []);
+        }
+
+        result
+    }
+
     fn list_versions(&self, resource_id: i64) -> Result<Vec<Version>, StoreError> {
         let mut stmt = self
             .conn
@@ -190,6 +305,23 @@ impl ResourceStore for SqliteResourceStore {
             .map_err(db_err)?;
 
         rows.collect::<Result<Vec<_>, _>>().map_err(db_err)
+    }
+
+    fn get_version(&self, resource_id: i64, version: &str) -> Result<Version, StoreError> {
+        self.conn
+            .query_row(
+                "SELECT id, resource_id, version, store_path, checksum, manifest_json, published_by, published_at
+                 FROM versions
+                 WHERE resource_id = ?1 AND version = ?2",
+                (resource_id, version),
+                version_from_row,
+            )
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => {
+                    StoreError::NotFound(format!("version '{version}' not found"))
+                }
+                other => db_err(other),
+            })
     }
 
     fn publish(&self, resource: &Resource, version: &Version) -> Result<(), StoreError> {
@@ -476,5 +608,145 @@ mod tests {
             .get_resource(Some("myteam"), "denden", ResourceType::Skill)
             .unwrap();
         assert_eq!(s.latest_version.as_deref(), Some("2.0.0"));
+    }
+
+    // -- create_resource tests --
+
+    #[test]
+    fn create_resource_returns_created() {
+        let store = test_store();
+        let resource = sample_resource();
+        let created = store.create_resource(&resource).unwrap();
+        assert_eq!(created.name, "denden");
+        assert_eq!(created.resource_type, "skill");
+        assert!(created.id > 0);
+        assert!(created.updated_at.is_some());
+    }
+
+    #[test]
+    fn create_resource_duplicate_errors() {
+        let store = test_store();
+        let resource = sample_resource();
+        store.create_resource(&resource).unwrap();
+        let result = store.create_resource(&resource);
+        assert!(matches!(result, Err(StoreError::AlreadyExists(_))));
+    }
+
+    // -- delete_resource tests --
+
+    #[test]
+    fn delete_resource_removes_resource() {
+        let store = test_store();
+        store.create_resource(&sample_resource()).unwrap();
+
+        store
+            .delete_resource(None, "denden", ResourceType::Skill)
+            .unwrap();
+
+        let result = store.get_resource(None, "denden", ResourceType::Skill);
+        assert!(matches!(result, Err(StoreError::NotFound(_))));
+    }
+
+    #[test]
+    fn delete_resource_cascades_versions() {
+        let store = test_store();
+        store
+            .publish(&sample_resource(), &sample_version("1.0.0"))
+            .unwrap();
+        store
+            .publish(&sample_resource(), &sample_version("2.0.0"))
+            .unwrap();
+
+        let resource = store
+            .get_resource(None, "denden", ResourceType::Skill)
+            .unwrap();
+        assert_eq!(store.list_versions(resource.id).unwrap().len(), 2);
+
+        store
+            .delete_resource(None, "denden", ResourceType::Skill)
+            .unwrap();
+
+        // Verify versions are also gone (use raw query since resource is deleted).
+        let count: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM versions WHERE resource_id = ?1",
+                [resource.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn delete_resource_not_found_errors() {
+        let store = test_store();
+        let result = store.delete_resource(None, "nonexistent", ResourceType::Skill);
+        assert!(matches!(result, Err(StoreError::NotFound(_))));
+    }
+
+    // -- list_resources tests --
+
+    #[test]
+    fn list_resources_all() {
+        let store = test_store();
+        store.create_resource(&sample_resource()).unwrap();
+
+        let mut agent = sample_resource();
+        agent.name = "debugger".to_string();
+        agent.resource_type = "agent".to_string();
+        store.create_resource(&agent).unwrap();
+
+        let all = store.list_resources(None).unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn list_resources_with_type_filter() {
+        let store = test_store();
+        store.create_resource(&sample_resource()).unwrap();
+
+        let mut agent = sample_resource();
+        agent.name = "debugger".to_string();
+        agent.resource_type = "agent".to_string();
+        store.create_resource(&agent).unwrap();
+
+        let skills = store.list_resources(Some(ResourceType::Skill)).unwrap();
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "denden");
+
+        let agents = store.list_resources(Some(ResourceType::Agent)).unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].name, "debugger");
+    }
+
+    // -- get_version tests --
+
+    #[test]
+    fn get_version_found() {
+        let store = test_store();
+        store
+            .publish(&sample_resource(), &sample_version("1.0.0"))
+            .unwrap();
+
+        let resource = store
+            .get_resource(None, "denden", ResourceType::Skill)
+            .unwrap();
+        let version = store.get_version(resource.id, "1.0.0").unwrap();
+        assert_eq!(version.version, "1.0.0");
+    }
+
+    #[test]
+    fn get_version_not_found_errors() {
+        let store = test_store();
+        store
+            .publish(&sample_resource(), &sample_version("1.0.0"))
+            .unwrap();
+
+        let resource = store
+            .get_resource(None, "denden", ResourceType::Skill)
+            .unwrap();
+        let result = store.get_version(resource.id, "9.9.9");
+        assert!(matches!(result, Err(StoreError::NotFound(_))));
     }
 }

--- a/crates/relava-server/src/store/mod.rs
+++ b/crates/relava-server/src/store/mod.rs
@@ -1,12 +1,8 @@
-// TODO: remove these allows once the store module is wired into routes
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
 mod blob;
-mod db;
+pub mod db;
 mod dirs;
-mod models;
-mod traits;
+pub mod models;
+pub mod traits;
 
 pub use blob::LocalBlobStore;
 pub use db::SqliteResourceStore;

--- a/crates/relava-server/src/store/traits.rs
+++ b/crates/relava-server/src/store/traits.rs
@@ -43,7 +43,23 @@ pub trait ResourceStore {
         resource_type: ResourceType,
     ) -> Result<Resource, StoreError>;
 
+    fn list_resources(
+        &self,
+        resource_type: Option<ResourceType>,
+    ) -> Result<Vec<Resource>, StoreError>;
+
+    fn create_resource(&self, resource: &Resource) -> Result<Resource, StoreError>;
+
+    fn delete_resource(
+        &self,
+        scope: Option<&str>,
+        name: &str,
+        resource_type: ResourceType,
+    ) -> Result<(), StoreError>;
+
     fn list_versions(&self, resource_id: i64) -> Result<Vec<Version>, StoreError>;
+
+    fn get_version(&self, resource_id: i64, version: &str) -> Result<Version, StoreError>;
 
     fn publish(&self, resource: &Resource, version: &Version) -> Result<(), StoreError>;
 


### PR DESCRIPTION
## Summary
- Implements Issue #36 — REST endpoints for resources and versions CRUD under `/api/v1`
- Adds 6 endpoints: `GET /resources` (with `?type=` filter), `GET/POST/DELETE /resources/:type/:name`, `GET /resources/:type/:name/versions`, `GET /resources/:type/:name/versions/:version`
- Extends `ResourceStore` trait with `list_resources`, `create_resource`, `delete_resource`, `get_version` methods
- Server binary now initializes `~/.relava/` directory structure and opens SQLite database at startup

### Key design decisions
- `Mutex<SqliteResourceStore>` in `AppState` with `acquire_store()` helper that returns 500 on poisoning instead of panicking
- Internal errors (DB, IO) logged to stderr; generic "internal server error" returned to clients (no information leakage)
- Atomic delete via `BEGIN IMMEDIATE`/`COMMIT` transaction with `ROLLBACK` on error
- Explicit duplicate check in `create_resource` (SQLite `NULL != NULL` in UNIQUE constraints)
- Input validation on all endpoints: slug format, resource type enum, semver version strings
- Proper HTTP status codes: 200 OK, 201 Created, 204 No Content, 400 Bad Request, 404 Not Found, 409 Conflict, 422 Unprocessable Entity

### Stats
- +1,158 lines across 6 files (1 new: `routes.rs`, 5 modified)
- 56 server tests (29 new), 540 total workspace tests pass
- Clippy clean with `-D warnings`

Closes #36

## Test plan
- [x] All 56 relava-server tests pass (29 new route + store tests)
- [x] All 540 workspace tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p relava-server -- -D warnings` clean
- [x] Full Build → Simplify (4 refinements) → Review (2 critical + 3 suggestions fixed) → Second Review (1 clippy fix) chain completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)