### PR TITLE
Add search endpoint with SQLite FTS5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +91,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -183,6 +198,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -316,6 +342,36 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -724,6 +780,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +952,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1122,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1246,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1268,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1279,6 +1419,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "tempfile",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1375,11 +1516,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
 dependencies = [
  "bitflags",
+ "chrono",
+ "csv",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
+ "jiff",
  "libsqlite3-sys",
+ "serde_json",
  "smallvec",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1731,6 +1879,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +2148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2164,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -2149,6 +2344,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2024"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
-rusqlite = { version = "0.34", features = ["bundled"] }
+rusqlite = { version = "0.34", features = ["bundled-full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/relava-cli/Cargo.toml
+++ b/crates/relava-cli/Cargo.toml
@@ -20,6 +20,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+urlencoding = "2"
 
 [dev-dependencies]
 base64.workspace = true

--- a/crates/relava-cli/src/api_client.rs
+++ b/crates/relava-cli/src/api_client.rs
@@ -179,6 +179,20 @@ impl ApiClient {
         self.get_json(&path)
     }
 
+    /// Search resources using full-text search, optionally filtered by type.
+    pub fn search_resources(
+        &self,
+        query: &str,
+        type_filter: Option<&str>,
+    ) -> Result<Vec<ResourceResponse>, ApiError> {
+        let encoded_query = urlencoding::encode(query);
+        let mut path = format!("/api/v1/resources?q={encoded_query}");
+        if let Some(t) = type_filter {
+            path.push_str(&format!("&type={}", urlencoding::encode(t)));
+        }
+        self.get_json(&path)
+    }
+
     /// Get a single resource by type and name.
     pub fn get_resource(
         &self,

--- a/crates/relava-cli/src/cli.rs
+++ b/crates/relava-cli/src/cli.rs
@@ -92,6 +92,10 @@ pub enum Command {
     Search {
         /// Search query
         query: String,
+
+        /// Filter by resource type (skill, agent, command, rule)
+        #[arg(long, rename_all = "lowercase")]
+        r#type: Option<String>,
     },
 
     /// Update installed resources

--- a/crates/relava-cli/src/main.rs
+++ b/crates/relava-cli/src/main.rs
@@ -17,6 +17,7 @@ mod registry;
 mod remove;
 mod resolver;
 mod save;
+mod search;
 mod server;
 mod tools;
 mod update;
@@ -281,8 +282,22 @@ fn main() {
                 Err(e) => exit_with_error(&e, cli.json),
             }
         }
-        Command::Search { query } => {
-            println!("relava search {query}");
+        Command::Search { query, r#type } => {
+            let opts = search::SearchOpts {
+                server_url: &cli.server,
+                query: &query,
+                resource_type: r#type.as_deref(),
+                json: cli.json,
+            };
+
+            match search::run(&opts) {
+                Ok(result) => {
+                    if cli.json {
+                        print_json(&result);
+                    }
+                }
+                Err(e) => exit_with_error(&e, cli.json),
+            }
         }
         Command::Update {
             resource_type,

--- a/crates/relava-cli/src/search.rs
+++ b/crates/relava-cli/src/search.rs
@@ -1,0 +1,229 @@
+use crate::api_client::ApiClient;
+use crate::install;
+
+/// A single entry in the search results.
+#[derive(Debug, serde::Serialize)]
+pub struct SearchEntry {
+    pub name: String,
+    pub resource_type: String,
+    pub version: String,
+    pub description: String,
+}
+
+/// Result of the search command.
+#[derive(Debug, serde::Serialize)]
+pub struct SearchResult {
+    pub query: String,
+    pub results: Vec<SearchEntry>,
+}
+
+/// Options for the search command.
+pub struct SearchOpts<'a> {
+    pub server_url: &'a str,
+    pub query: &'a str,
+    pub resource_type: Option<&'a str>,
+    pub json: bool,
+}
+
+/// Run `relava search <query> [--type <type>]`.
+pub fn run(opts: &SearchOpts) -> Result<SearchResult, String> {
+    // Validate the type filter if provided.
+    if let Some(t) = opts.resource_type {
+        install::parse_resource_type(t).map_err(|e| e.to_string())?;
+    }
+
+    let client = ApiClient::new(opts.server_url);
+    let resources = client
+        .search_resources(opts.query, opts.resource_type)
+        .map_err(|e| e.to_string())?;
+
+    let results: Vec<SearchEntry> = resources
+        .into_iter()
+        .map(|r| SearchEntry {
+            name: r.name,
+            resource_type: r.resource_type,
+            version: r.latest_version.unwrap_or_default(),
+            description: r.description.unwrap_or_default(),
+        })
+        .collect();
+
+    if !opts.json {
+        if results.is_empty() {
+            println!("No results for '{}'.", opts.query);
+        } else {
+            print_table(&results);
+        }
+    }
+
+    Ok(SearchResult {
+        query: opts.query.to_string(),
+        results,
+    })
+}
+
+/// Print search results as a formatted table.
+fn print_table(entries: &[SearchEntry]) {
+    let rows: Vec<Vec<String>> = entries
+        .iter()
+        .map(|e| {
+            let version = if e.version.is_empty() {
+                "-"
+            } else {
+                &e.version
+            };
+            let snippet = truncate(&e.description, 60);
+            vec![
+                e.name.clone(),
+                e.resource_type.clone(),
+                version.to_string(),
+                snippet,
+            ]
+        })
+        .collect();
+
+    println!(
+        "{}",
+        crate::output::table(&["Name", "Type", "Version", "Description"], &rows)
+    );
+}
+
+/// Truncate a string to `max_len` characters, appending "..." if truncated.
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_len.saturating_sub(3)).collect();
+        format!("{truncated}...")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_short_string() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_long_string() {
+        let long = "a".repeat(100);
+        let result = truncate(&long, 60);
+        assert!(result.len() <= 60);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn truncate_exact_length() {
+        let s = "a".repeat(60);
+        assert_eq!(truncate(&s, 60), s);
+    }
+
+    #[test]
+    fn search_result_serializes_to_json() {
+        let result = SearchResult {
+            query: "denden".to_string(),
+            results: vec![SearchEntry {
+                name: "denden".to_string(),
+                resource_type: "skill".to_string(),
+                version: "1.0.0".to_string(),
+                description: "Communication skill".to_string(),
+            }],
+        };
+        let json = serde_json::to_string_pretty(&result).unwrap();
+        assert!(json.contains("denden"));
+        assert!(json.contains("1.0.0"));
+    }
+
+    #[test]
+    fn search_fails_when_server_unreachable() {
+        let opts = SearchOpts {
+            server_url: "http://127.0.0.1:19999",
+            query: "test",
+            resource_type: None,
+            json: true,
+        };
+        let err = run(&opts).unwrap_err();
+        assert!(err.contains("Registry server not running"), "got: {err}");
+    }
+
+    #[test]
+    fn search_with_invalid_type_fails() {
+        let opts = SearchOpts {
+            server_url: "http://127.0.0.1:19999",
+            query: "test",
+            resource_type: Some("invalid"),
+            json: true,
+        };
+        let err = run(&opts).unwrap_err();
+        assert!(
+            err.contains("invalid") || err.contains("must be"),
+            "got: {err}"
+        );
+    }
+
+    // --- Mockito integration tests ---
+
+    #[test]
+    fn search_returns_results() {
+        let mut server = mockito::Server::new();
+        let _mock = server
+            .mock("GET", "/api/v1/resources?q=denden")
+            .with_status(200)
+            .with_body(
+                r#"[{"name":"denden","type":"skill","description":"Communication skill","latest_version":"1.0.0"}]"#,
+            )
+            .create();
+
+        let opts = SearchOpts {
+            server_url: &server.url(),
+            query: "denden",
+            resource_type: None,
+            json: true,
+        };
+        let result = run(&opts).unwrap();
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].name, "denden");
+        assert_eq!(result.results[0].version, "1.0.0");
+    }
+
+    #[test]
+    fn search_with_type_filter() {
+        let mut server = mockito::Server::new();
+        let _mock = server
+            .mock("GET", "/api/v1/resources?q=debug&type=agent")
+            .with_status(200)
+            .with_body(r#"[{"name":"debugger","type":"agent","description":"Debug agent"}]"#)
+            .create();
+
+        let opts = SearchOpts {
+            server_url: &server.url(),
+            query: "debug",
+            resource_type: Some("agent"),
+            json: true,
+        };
+        let result = run(&opts).unwrap();
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].resource_type, "agent");
+    }
+
+    #[test]
+    fn search_empty_results() {
+        let mut server = mockito::Server::new();
+        let _mock = server
+            .mock("GET", "/api/v1/resources?q=nonexistent")
+            .with_status(200)
+            .with_body(r#"[]"#)
+            .create();
+
+        let opts = SearchOpts {
+            server_url: &server.url(),
+            query: "nonexistent",
+            resource_type: None,
+            json: true,
+        };
+        let result = run(&opts).unwrap();
+        assert!(result.results.is_empty());
+    }
+}

--- a/crates/relava-server/src/routes.rs
+++ b/crates/relava-server/src/routes.rs
@@ -172,6 +172,8 @@ impl From<Version> for VersionResponse {
 struct ListQuery {
     #[serde(rename = "type")]
     resource_type: Option<String>,
+    /// Full-text search query. When present, returns ranked search results.
+    q: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -188,7 +190,10 @@ struct ResolveQuery {
 // Handlers
 // ---------------------------------------------------------------------------
 
-/// GET /api/v1/resources?type=skill
+/// GET /api/v1/resources?type=skill&q=search+term
+///
+/// When `q` is provided, performs a full-text search using FTS5 and returns
+/// ranked results. Otherwise lists all resources with optional type filter.
 async fn list_resources(
     State(state): State<Arc<AppState>>,
     Query(query): Query<ListQuery>,
@@ -205,7 +210,14 @@ async fn list_resources(
         Ok(s) => s,
         Err(resp) => return resp,
     };
-    match store.list_resources(rt) {
+
+    let result = if let Some(ref q) = query.q {
+        store.search(q, rt)
+    } else {
+        store.list_resources(rt)
+    };
+
+    match result {
         Ok(resources) => {
             let body: Vec<ResourceResponse> = resources.into_iter().map(Into::into).collect();
             Json(body).into_response()
@@ -1043,5 +1055,148 @@ mod tests {
         // Verify resource and versions are gone
         let resp = send(app, "GET", "/api/v1/resources/skill/denden", None).await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // -- Search (FTS5) tests --
+
+    #[tokio::test]
+    async fn search_returns_matching_resources() {
+        let store = SqliteResourceStore::open_in_memory().unwrap();
+        publish(&store, "skill", "code-review", "1.0.0", None);
+        publish(&store, "skill", "security-baseline", "0.5.0", None);
+
+        let app = app_with_store(store);
+
+        let resp = send(app, "GET", "/api/v1/resources?q=code", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        let results = body.as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["name"], "code-review");
+    }
+
+    #[tokio::test]
+    async fn search_with_type_filter() {
+        let store = SqliteResourceStore::open_in_memory().unwrap();
+        publish(&store, "skill", "debugger", "1.0.0", None);
+        publish(&store, "agent", "debugger", "1.0.0", None);
+
+        let app = app_with_store(store);
+
+        // Search for "debugger" filtered to agents only
+        let resp = send(app, "GET", "/api/v1/resources?q=debugger&type=agent", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        let results = body.as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["type"], "agent");
+    }
+
+    #[tokio::test]
+    async fn search_no_results() {
+        let app = test_app();
+        let resp = send(app, "GET", "/api/v1/resources?q=nonexistent", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body.as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn search_by_description() {
+        let store = SqliteResourceStore::open_in_memory().unwrap();
+        let resource = crate::store::models::Resource {
+            id: 0,
+            scope: None,
+            name: "notify".to_string(),
+            resource_type: "skill".to_string(),
+            description: Some("Send notifications to Slack channels".to_string()),
+            latest_version: None,
+            metadata_json: None,
+            updated_at: None,
+        };
+        store
+            .publish(
+                &resource,
+                &crate::store::models::Version {
+                    id: 0,
+                    resource_id: 0,
+                    version: "1.0.0".to_string(),
+                    store_path: None,
+                    checksum: None,
+                    manifest_json: None,
+                    published_by: None,
+                    published_at: None,
+                },
+            )
+            .unwrap();
+
+        let app = app_with_store(store);
+        let resp = send(app, "GET", "/api/v1/resources?q=slack", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        let results = body.as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["name"], "notify");
+    }
+
+    #[tokio::test]
+    async fn search_deleted_resource_not_found() {
+        let app = test_app();
+        // Create, then delete
+        send(
+            app.clone(),
+            "POST",
+            "/api/v1/resources/skill/ephemeral",
+            Some(r#"{"description":"temporary"}"#),
+        )
+        .await;
+        send(
+            app.clone(),
+            "DELETE",
+            "/api/v1/resources/skill/ephemeral",
+            None,
+        )
+        .await;
+
+        // Search should not find the deleted resource
+        let resp = send(app, "GET", "/api/v1/resources?q=ephemeral", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body.as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn search_empty_query_returns_empty() {
+        let app = test_app();
+        send(
+            app.clone(),
+            "POST",
+            "/api/v1/resources/skill/denden",
+            Some(r#"{"description":"a skill"}"#),
+        )
+        .await;
+
+        let resp = send(app, "GET", "/api/v1/resources?q=", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body.as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn search_without_q_returns_all() {
+        let app = test_app();
+        send(
+            app.clone(),
+            "POST",
+            "/api/v1/resources/skill/denden",
+            Some(r#"{"description":"a skill"}"#),
+        )
+        .await;
+
+        // Without q param, should list all (not search)
+        let resp = send(app, "GET", "/api/v1/resources", None).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body.as_array().unwrap().len(), 1);
     }
 }

--- a/crates/relava-server/src/store/db.rs
+++ b/crates/relava-server/src/store/db.rs
@@ -40,7 +40,7 @@ fn version_from_row(row: &Row<'_>) -> rusqlite::Result<Version> {
 }
 
 /// Current schema version. Increment when adding migrations.
-const SCHEMA_VERSION: i64 = 1;
+const SCHEMA_VERSION: i64 = 2;
 
 /// SQLite-backed implementation of `ResourceStore`.
 pub struct SqliteResourceStore {
@@ -88,8 +88,9 @@ impl SqliteResourceStore {
             self.migrate_v1()?;
         }
 
-        // Future migrations go here:
-        // if current < 2 { self.migrate_v2()?; }
+        if current < 2 {
+            self.migrate_v2()?;
+        }
 
         if current < SCHEMA_VERSION {
             self.conn
@@ -146,6 +147,80 @@ impl SqliteResourceStore {
             .map_err(|e| StoreError::Database(format!("migration v1 failed: {e}")))?;
         Ok(())
     }
+
+    fn migrate_v2(&self) -> Result<(), StoreError> {
+        self.conn
+            .execute_batch(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS resources_fts USING fts5(
+                    name,
+                    description,
+                    keywords,
+                    resource_type
+                );",
+            )
+            .map_err(|e| StoreError::Database(format!("migration v2 (FTS5) failed: {e}")))?;
+
+        // Clear any partial FTS data (idempotent re-run safety), then back-fill.
+        self.conn
+            .execute_batch("DELETE FROM resources_fts;")
+            .map_err(|e| StoreError::Database(format!("FTS5 cleanup failed: {e}")))?;
+
+        self.conn
+            .execute_batch(
+                "INSERT INTO resources_fts(rowid, name, description, keywords, resource_type)
+                 SELECT id, name, COALESCE(description, ''), '', type
+                 FROM resources;",
+            )
+            .map_err(|e| StoreError::Database(format!("FTS5 back-fill failed: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Update the FTS index for a resource after publish or update.
+    fn update_fts_index(&self, resource_id: i64, resource: &Resource) -> Result<(), StoreError> {
+        self.conn
+            .execute("DELETE FROM resources_fts WHERE rowid = ?1", [resource_id])
+            .map_err(db_err)?;
+
+        let keywords = extract_keywords(resource.metadata_json.as_deref());
+
+        self.conn
+            .execute(
+                "INSERT INTO resources_fts(rowid, name, description, keywords, resource_type) VALUES(?1, ?2, ?3, ?4, ?5)",
+                (
+                    resource_id,
+                    &resource.name,
+                    resource.description.as_deref().unwrap_or(""),
+                    &keywords,
+                    &resource.resource_type,
+                ),
+            )
+            .map_err(db_err)?;
+
+        Ok(())
+    }
+}
+
+/// Extract keywords from a JSON metadata string.
+///
+/// Expects `{"keywords": ["foo", "bar"]}` and returns `"foo bar"`.
+fn extract_keywords(metadata_json: Option<&str>) -> String {
+    let Some(json) = metadata_json else {
+        return String::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return String::new();
+    };
+    value
+        .get("keywords")
+        .and_then(|k| k.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .unwrap_or_default()
 }
 
 impl ResourceStore for SqliteResourceStore {
@@ -232,14 +307,19 @@ impl ResourceStore for SqliteResourceStore {
             .map_err(db_err)?;
 
         let id = self.conn.last_insert_rowid();
-        self.conn
+        let created = self.conn
             .query_row(
                 "SELECT id, scope, name, type, description, latest_version, metadata_json, updated_at
                  FROM resources WHERE id = ?1",
                 [id],
                 resource_from_row,
             )
-            .map_err(db_err)
+            .map_err(db_err)?;
+
+        // Add to FTS index.
+        self.update_fts_index(id, &created)?;
+
+        Ok(created)
     }
 
     fn delete_resource(
@@ -268,6 +348,11 @@ impl ResourceStore for SqliteResourceStore {
                     }
                     other => db_err(other),
                 })?;
+
+            // Remove from FTS index before deleting the resource.
+            self.conn
+                .execute("DELETE FROM resources_fts WHERE rowid = ?1", [resource_id])
+                .map_err(db_err)?;
 
             // Delete all versions first, then the resource.
             self.conn
@@ -396,6 +481,8 @@ impl ResourceStore for SqliteResourceStore {
                 other => db_err(other),
             })?;
 
+        self.update_fts_index(resource_id, resource)?;
+
         Ok(())
     }
 
@@ -404,26 +491,38 @@ impl ResourceStore for SqliteResourceStore {
         query: &str,
         resource_type: Option<ResourceType>,
     ) -> Result<Vec<Resource>, StoreError> {
-        let pattern = format!("%{query}%");
+        // Sanitize the query for FTS5: wrap each token in double quotes to
+        // prevent FTS syntax injection, append * for prefix matching, and
+        // combine with implicit AND.
+        let fts_query: String = query
+            .split_whitespace()
+            .map(|token| {
+                let escaped = token.replace('"', "\"\"");
+                format!("\"{escaped}\"*")
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
 
-        if let Some(rt) = resource_type {
-            let rt_str = rt.to_string();
-            self.query_resources(
-                "SELECT id, scope, name, type, description, latest_version, metadata_json, updated_at
-                 FROM resources
-                 WHERE (name LIKE ?1 OR description LIKE ?1) AND type = ?2
-                 ORDER BY name",
-                &[&pattern as &dyn ToSql, &rt_str],
-            )
-        } else {
-            self.query_resources(
-                "SELECT id, scope, name, type, description, latest_version, metadata_json, updated_at
-                 FROM resources
-                 WHERE (name LIKE ?1 OR description LIKE ?1)
-                 ORDER BY name",
-                &[&pattern as &dyn ToSql],
-            )
+        if fts_query.is_empty() {
+            return Ok(Vec::new());
         }
+
+        let mut sql = String::from(
+            "SELECT r.id, r.scope, r.name, r.type, r.description, r.latest_version, r.metadata_json, r.updated_at
+             FROM resources_fts f
+             JOIN resources r ON r.id = f.rowid
+             WHERE resources_fts MATCH ?1",
+        );
+        let mut params: Vec<&dyn ToSql> = vec![&fts_query];
+
+        let rt_str = resource_type.map(|rt| rt.to_string());
+        if let Some(ref rt) = rt_str {
+            sql.push_str(" AND r.type = ?2");
+            params.push(rt);
+        }
+
+        sql.push_str(" ORDER BY rank");
+        self.query_resources(&sql, &params)
     }
 }
 
@@ -587,6 +686,35 @@ mod tests {
         let store = test_store();
         let results = store.search("nonexistent", None).unwrap();
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn search_handles_fts_syntax_in_query() {
+        let store = test_store();
+        store
+            .publish(&sample_resource(), &sample_version("1.0.0"))
+            .unwrap();
+
+        // FTS5 operators should not cause parse errors.
+        let _ = store.search("OR AND NEAR", None).unwrap();
+        let _ = store.search("\"quoted\"", None).unwrap();
+        let _ = store.search("prefix*", None).unwrap();
+        let _ = store.search("den OR something", None).unwrap();
+    }
+
+    #[test]
+    fn search_by_keywords() {
+        let store = test_store();
+        let mut resource = sample_resource();
+        resource.metadata_json = Some(r#"{"keywords":["monitoring","alerting"]}"#.to_string());
+        store.publish(&resource, &sample_version("1.0.0")).unwrap();
+
+        let results = store.search("monitoring", None).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "denden");
+
+        let results = store.search("alerting", None).unwrap();
+        assert_eq!(results.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #39

- **FTS5 virtual table** (v2 migration) indexing resource name, description, and keywords with automatic back-fill from existing data
- **FTS index updated automatically** when resources are published, created, or deleted
- **`GET /resources?q=<query>&type=<type>`** returns ranked search results via FTS5 with prefix matching and syntax injection protection
- **`relava search <query>`** CLI command displays results in a formatted table (name, type, version, description snippet)
- **`--type` filter** and **`--json` output** supported on search command
- rusqlite upgraded from `bundled` to `bundled-full` for FTS5 support
- Added `urlencoding` crate for query parameter encoding

## Test plan

- [x] 609 total tests passing (449 CLI + 93 server + 67 types)
- [x] 7 new HTTP integration tests for search endpoint (name match, type filter, no results, description match, deleted resource, empty query, without-q fallback)
- [x] 2 new store tests (FTS syntax injection resistance, keyword-based search)
- [x] 8 new CLI search tests (3 mockito integration + 5 unit)
- [x] Clippy clean, fmt clean
- [x] Code-simplifier: 5 refinements applied (merged impl blocks, flattened extract_keywords, deduplicated search SQL, removed redundant comments, simplified version display)
- [x] PR-reviewer: 1 important issue fixed (migration idempotency), 3 suggestions addressed (URL encoding, FTS injection test, keyword search test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)